### PR TITLE
feat: Walk-in token reservation with ETA and progress bar fixes

### DIFF
--- a/client/src/pages/attender-dashboard.tsx
+++ b/client/src/pages/attender-dashboard.tsx
@@ -77,6 +77,14 @@ export default function AttenderDashboard() {
     scheduleId: number;
     date: Date;
   } | null>(null);
+  const [walkInReservation, setWalkInReservation] = useState<{
+    id: number;
+    tokenNumber: number;
+    expiresAt: string;
+    scheduleId: number;
+  } | null>(null);
+  const [walkInStep, setWalkInStep] = useState<'idle' | 'reserving' | 'filling'>('idle');
+  const [reservationSecondsLeft, setReservationSecondsLeft] = useState(300);
 
   // Main query for fetching doctor data with schedules and appointments  
   const { data: managedDoctors, isLoading, error } = useQuery<DoctorWithAppointments[]>({
@@ -251,12 +259,41 @@ export default function AttenderDashboard() {
     }
   });
 
+  // Reset all walk-in dialog state (defined early so useEffects can reference it)
+  const resetWalkInDialog = () => {
+    setWalkInStep('idle');
+    setWalkInReservation(null);
+    setWalkInCurrentDoctor(null);
+    setWalkInFormValues({ doctorId: 0, clinicId: 0, scheduleId: 0, guestName: '', guestPhone: '' });
+    setReservationSecondsLeft(300);
+  };
+
   // Auto-select the first doctor when data loads
   useEffect(() => {
     if (managedDoctors && managedDoctors.length > 0 && !selectedDoctorId) {
       setSelectedDoctorId(managedDoctors[0].doctor.id.toString());
     }
   }, [managedDoctors, selectedDoctorId]);
+
+  // Countdown timer for walk-in reservation
+  useEffect(() => {
+    if (walkInStep !== 'filling') return;
+    if (reservationSecondsLeft <= 0) {
+      toast({ title: "Reservation expired. Please try again.", variant: "destructive" });
+      // Cancel the reservation so the token is freed immediately
+      if (walkInReservation) {
+        cancelReservationMutation.mutate({
+          scheduleId: walkInReservation.scheduleId,
+          reservationId: walkInReservation.id
+        });
+      }
+      resetWalkInDialog();
+      setIsWalkInDialogOpen(false);
+      return;
+    }
+    const timer = setInterval(() => setReservationSecondsLeft(s => s - 1), 1000);
+    return () => clearInterval(timer);
+  }, [walkInStep, reservationSecondsLeft]);
 
   // Helper function to get presence data for a doctor's schedule
   const getPresenceData = (doctorId: number, scheduleId: number) => {
@@ -374,6 +411,58 @@ export default function AttenderDashboard() {
         description: error.message,
         variant: "destructive"
       });
+    }
+  });
+
+  const reserveTokenMutation = useMutation({
+    mutationFn: async (scheduleId: number) => {
+      const res = await apiRequest("POST", `/api/schedules/${scheduleId}/reserve-token`, {});
+      return res.json();
+    },
+    onSuccess: (data) => {
+      setWalkInReservation(data);
+      setWalkInStep('filling');
+      setReservationSecondsLeft(300);
+    },
+    onError: () => {
+      toast({ title: "Failed to reserve token", variant: "destructive" });
+      setWalkInStep('idle');
+    }
+  });
+
+  const confirmWalkInMutation = useMutation({
+    mutationFn: async ({ scheduleId, reservationId, guestName, guestPhone }: {
+      scheduleId: number; reservationId: number; guestName: string; guestPhone: string;
+    }) => {
+      const res = await apiRequest("POST", `/api/schedules/${scheduleId}/confirm-walkin`, {
+        reservationId, guestName, guestPhone
+      });
+      return res.json();
+    },
+    onSuccess: (data) => {
+      const reservedToken = walkInReservation?.tokenNumber;
+      const confirmedToken = data?.tokenNumber;
+      if (reservedToken && confirmedToken && reservedToken !== confirmedToken) {
+        toast({
+          title: `Walk-in assigned Token #${confirmedToken}`,
+          description: `Reserved slot #${reservedToken} was taken; reassigned to #${confirmedToken}.`,
+          variant: "destructive"
+        });
+      } else {
+        toast({ title: `Walk-in Token #${confirmedToken ?? reservedToken} confirmed!` });
+      }
+      resetWalkInDialog();
+      setIsWalkInDialogOpen(false);
+      queryClient.invalidateQueries({ queryKey: [`/api/attender/${user?.id}/doctors/appointments`] });
+    },
+    onError: (error: any) => {
+      toast({ title: error.message || "Failed to confirm walk-in", variant: "destructive" });
+    }
+  });
+
+  const cancelReservationMutation = useMutation({
+    mutationFn: async ({ scheduleId, reservationId }: { scheduleId: number; reservationId: number }) => {
+      await apiRequest("DELETE", `/api/schedules/${scheduleId}/reservation/${reservationId}`, {});
     }
   });
 
@@ -501,7 +590,7 @@ export default function AttenderDashboard() {
 
   const handleCreateWalkInAppointment = () => {
     if (!walkInCurrentDoctor) return;
-    
+
     if (!walkInFormValues.guestName.trim()) {
       toast({
         title: "Error",
@@ -510,7 +599,7 @@ export default function AttenderDashboard() {
       });
       return;
     }
-    
+
     createWalkInAppointmentMutation.mutate({
       doctorId: walkInCurrentDoctor.doctorId,
       clinicId: walkInCurrentDoctor.clinicId,
@@ -521,31 +610,25 @@ export default function AttenderDashboard() {
     });
   };
 
-  // Add this function to open the walk-in dialog with doctor info
+  const handleWalkInDialogClose = (open: boolean) => {
+    if (!open && walkInReservation && walkInStep === 'filling') {
+      cancelReservationMutation.mutate({
+        scheduleId: walkInReservation.scheduleId,
+        reservationId: walkInReservation.id
+      });
+    }
+    if (!open) resetWalkInDialog();
+    setIsWalkInDialogOpen(open);
+  };
+
+  // Open the walk-in dialog — immediately reserve a token (2-step flow)
   const openWalkInDialog = (doctorId: number, doctorName: string, clinicId: number, scheduleId: number) => {
-    // Create a date object for the current date
     const appointmentDate = new Date(selectedDate);
-    
-    // Set the doctor info
-    setWalkInCurrentDoctor({
-      doctorId,
-      doctorName,
-      clinicId,
-      scheduleId,
-      date: appointmentDate
-    });
-    
-    // Update form values
-    setWalkInFormValues({
-      doctorId,
-      clinicId,
-      scheduleId,
-      guestName: "",
-      guestPhone: ""
-    });
-    
-    // Open the dialog
+    setWalkInCurrentDoctor({ doctorId, doctorName, clinicId, scheduleId, date: appointmentDate });
+    setWalkInFormValues({ doctorId, clinicId, scheduleId, guestName: "", guestPhone: "" });
     setIsWalkInDialogOpen(true);
+    setWalkInStep('reserving');
+    reserveTokenMutation.mutate(scheduleId);
   };
 
   // Handler for toggling schedule pause
@@ -1008,60 +1091,79 @@ export default function AttenderDashboard() {
             </Card>
         </main>
       </TooltipProvider>
-      <Dialog open={isWalkInDialogOpen} onOpenChange={setIsWalkInDialogOpen}>
+      <Dialog open={isWalkInDialogOpen} onOpenChange={handleWalkInDialogClose}>
         <DialogContent className="sm:max-w-[425px]">
           <DialogHeader>
             <DialogTitle>Create Walk-in Token</DialogTitle>
             <DialogDescription>
               {walkInCurrentDoctor && (
-                <p>Creating Token for Dr. {walkInCurrentDoctor.doctorName} on {format(selectedDate, "PPP")}</p>
+                <span>Creating Token for Dr. {walkInCurrentDoctor.doctorName} on {format(selectedDate, "PPP")}</span>
               )}
             </DialogDescription>
           </DialogHeader>
-          
-          <div className="grid gap-4 py-4">
-            <div className="grid grid-cols-4 items-center gap-4">
-              <Label htmlFor="guestName" className="text-right col-span-1">
-                Patient Name
-              </Label>
-              <Input
-                id="guestName"
-                placeholder="Enter patient name"
-                className="col-span-3"
-                value={walkInFormValues.guestName}
-                onChange={(e) => setWalkInFormValues({
-                  ...walkInFormValues,
-                  guestName: e.target.value
-                })}
-              />
+
+          {/* Step: Reserving (loading state) */}
+          {walkInStep === 'reserving' && (
+            <div className="flex flex-col items-center gap-4 py-8">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+              <p className="text-muted-foreground">Reserving your token...</p>
             </div>
-            
-            <div className="grid grid-cols-4 items-center gap-4">
-              <Label htmlFor="guestPhone" className="text-right col-span-1">
-                Phone Number
-              </Label>
-              <Input
-                id="guestPhone"
-                placeholder="Enter phone number (optional)"
-                className="col-span-3"
-                value={walkInFormValues.guestPhone}
-                onChange={(e) => setWalkInFormValues({
-                  ...walkInFormValues,
-                  guestPhone: e.target.value
-                })}
-              />
+          )}
+
+          {/* Step: Filling details */}
+          {walkInStep === 'filling' && walkInReservation && (
+            <div className="space-y-4">
+              {/* Reserved token badge */}
+              <div className="flex items-center justify-between p-3 bg-blue-50 rounded-lg border border-blue-200">
+                <div>
+                  <p className="text-sm text-blue-600 font-medium">Token Reserved</p>
+                  <p className="text-2xl font-bold text-blue-700">#{walkInReservation.tokenNumber}</p>
+                </div>
+                <div className="text-right">
+                  <p className="text-xs text-muted-foreground">Expires in</p>
+                  <p className={`text-lg font-bold ${reservationSecondsLeft < 60 ? 'text-red-500' : 'text-orange-500'}`}>
+                    {Math.floor(reservationSecondsLeft / 60)}:{String(reservationSecondsLeft % 60).padStart(2, '0')}
+                  </p>
+                </div>
+              </div>
+
+              {/* Guest details form */}
+              <div className="space-y-3">
+                <div>
+                  <Label>Patient Name *</Label>
+                  <Input
+                    placeholder="Enter patient name"
+                    value={walkInFormValues.guestName}
+                    onChange={e => setWalkInFormValues(v => ({ ...v, guestName: e.target.value }))}
+                  />
+                </div>
+                <div>
+                  <Label>Phone Number (optional)</Label>
+                  <Input
+                    placeholder="Enter phone number"
+                    value={walkInFormValues.guestPhone}
+                    onChange={e => setWalkInFormValues(v => ({ ...v, guestPhone: e.target.value }))}
+                  />
+                </div>
+              </div>
+
+              <Button
+                className="w-full"
+                disabled={!walkInFormValues.guestName.trim() || confirmWalkInMutation.isPending}
+                onClick={() => {
+                  if (!walkInReservation || !walkInCurrentDoctor) return;
+                  confirmWalkInMutation.mutate({
+                    scheduleId: walkInReservation.scheduleId,
+                    reservationId: walkInReservation.id,
+                    guestName: walkInFormValues.guestName,
+                    guestPhone: walkInFormValues.guestPhone
+                  });
+                }}
+              >
+                {confirmWalkInMutation.isPending ? "Confirming..." : "Confirm Walk-in"}
+              </Button>
             </div>
-          </div>
-          
-          <DialogFooter>
-            <Button
-              type="submit"
-              onClick={handleCreateWalkInAppointment}
-              disabled={createWalkInAppointmentMutation.isPending}
-            >
-              {createWalkInAppointmentMutation.isPending ? "Creating..." : "Create Token"}
-            </Button>
-          </DialogFooter>
+          )}
         </DialogContent>
       </Dialog>
     </div>

--- a/client/src/pages/booking-history.tsx
+++ b/client/src/pages/booking-history.tsx
@@ -127,8 +127,10 @@ export default function BookingHistoryPage() {
 
   // Fetch doctor arrival status - memoize this function to avoid recreating it on every render
   const fetchDoctorArrivals = useCallback(async () => {
-    // Skip if no scheduled appointments
-    const scheduledAppts = todayAppointments.filter(apt => apt.status === "token_started");
+    // Skip if no active appointments
+    const scheduledAppts = todayAppointments.filter(
+      apt => !["cancel", "completed", "no_show"].includes(apt.status)
+    );
     if (scheduledAppts.length === 0) return;
     
     const arrivalsMap: Record<string, boolean> = {};
@@ -159,8 +161,10 @@ export default function BookingHistoryPage() {
 
   // Setup the initial fetch and interval
   useEffect(() => {
-    // Only run this effect if we have scheduled appointments and haven't fetched yet
-    const hasScheduledAppointments = todayAppointments.some(apt => apt.status === "token_started");
+    // Only run this effect if we have active appointments (any non-terminal status) and haven't fetched yet
+    const hasScheduledAppointments = todayAppointments.some(
+      apt => !["cancel", "completed", "no_show"].includes(apt.status)
+    );
     
     if (hasScheduledAppointments) {
       // Run the initial fetch if we haven't already

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -581,17 +581,17 @@ export async function registerRoutes(app: Express): Promise<Server> {
         }
       }
 
-      // Get current token count for this date
+      // Get current token count for this date (includes pending walk-in reservations)
       const appointments = await storage.getAppointmentCountForDoctor(
         Number(req.body.doctorId),
         clinicId,
         schedule.id
       );
-      
+
       // Check if token limit has been reached
       if (schedule.maxTokens !== null && schedule.maxTokens !== undefined && appointments >= schedule.maxTokens) {
-        return res.status(400).json({ 
-          message: `Maximum number of tokens (${schedule.maxTokens}) has been reached for this schedule` 
+        return res.status(400).json({
+          message: `Maximum number of tokens (${schedule.maxTokens}) has been reached for this schedule`
         });
       }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2323,6 +2323,47 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  // Reserve next token number instantly for walk-in (step 1 of 2-step flow)
+  app.post("/api/schedules/:scheduleId/reserve-token", async (req, res) => {
+    if (!req.user || !['attender', 'clinic_admin'].includes(req.user.role)) return res.sendStatus(403);
+    try {
+      const scheduleId = parseInt(req.params.scheduleId);
+      const reservation = await storage.reserveNextToken(scheduleId, req.user.id);
+      res.status(201).json(reservation);
+    } catch (error) {
+      console.error('Error reserving token:', error);
+      res.status(500).json({ message: error instanceof Error ? error.message : 'Failed to reserve token' });
+    }
+  });
+
+  // Confirm walk-in with reserved token (step 2 of 2-step flow)
+  app.post("/api/schedules/:scheduleId/confirm-walkin", async (req, res) => {
+    if (!req.user || !['attender', 'clinic_admin'].includes(req.user.role)) return res.sendStatus(403);
+    try {
+      const scheduleId = parseInt(req.params.scheduleId);
+      const { reservationId, guestName, guestPhone } = req.body;
+      if (!reservationId || !guestName) {
+        return res.status(400).json({ message: 'reservationId and guestName are required' });
+      }
+      const appointment = await storage.confirmTokenReservation(Number(reservationId), guestName, guestPhone);
+      res.status(201).json(appointment);
+    } catch (error) {
+      console.error('Error confirming walk-in:', error);
+      res.status(400).json({ message: error instanceof Error ? error.message : 'Failed to confirm walk-in' });
+    }
+  });
+
+  // Cancel a token reservation
+  app.delete("/api/schedules/:scheduleId/reservation/:reservationId", async (req, res) => {
+    if (!req.user || !['attender', 'clinic_admin'].includes(req.user.role)) return res.sendStatus(403);
+    try {
+      await storage.cancelTokenReservation(parseInt(req.params.reservationId), req.user.id);
+      res.json({ message: 'Reservation cancelled' });
+    } catch (error) {
+      res.status(500).json({ message: 'Failed to cancel reservation' });
+    }
+  });
+
   // Add a new endpoint for attenders to create walk-in appointments
   app.post("/api/attender/walk-in-appointments", async (req, res) => {
     if (!req.user || !['attender', 'clinic_admin'].includes(req.user.role)) return res.sendStatus(403);

--- a/server/services/eta.ts
+++ b/server/services/eta.ts
@@ -1,6 +1,6 @@
 import { db } from "../db";
 import { appointments, doctorSchedules } from "@shared/schema";
-import { eq, and, lt, gte, desc, asc, ne, isNull, not, or, sql } from "drizzle-orm";
+import { eq, and, lt, gte, desc, asc, ne, isNull, not, or, sql, inArray } from "drizzle-orm";
 import { format, parse, addMinutes, differenceInMinutes, setHours, setMinutes } from "date-fns";
 
 export interface ETACalculationResult {
@@ -520,6 +520,7 @@ export class ETAService {
         tokenNumber: appointments.tokenNumber,
         scheduleId: appointments.scheduleId,
         estimatedStartTime: appointments.estimatedStartTime,
+        actualEndTime: appointments.actualEndTime,
         status: appointments.status,
         date: appointments.date
       })
@@ -599,8 +600,9 @@ export class ETAService {
     let liveEstimatedStartTime: Date;
 
     if (appointment[0].status === "completed") {
-      // Completed — just show stored value (actual start time)
-      liveEstimatedStartTime = estimatedStartTime || now;
+      // Completed — show actual end time if available, otherwise fall back to stored estimate
+      const actualEnd = appointment[0].actualEndTime ? new Date(appointment[0].actualEndTime) : null;
+      liveEstimatedStartTime = actualEnd || (estimatedStartTime ? new Date(estimatedStartTime) : now);
     } else if (appointment[0].status === "in_progress") {
       // Currently being seen — ETA = estimated finish = max(actualStart + avg, now)
       const actualStart = currentConsulting[0]?.actualStartTime
@@ -619,29 +621,28 @@ export class ETAService {
           addMinutes(actualStart, avgConsultationTime).getTime(),
           now.getTime()
         ));
-        // Count how many token_started patients are ahead of this one
+        // Count how many waiting patients (token_started or scheduled) are ahead of this one
         const aheadCount = await db
           .select({ count: sql<number>`COUNT(*)::integer` })
           .from(appointments)
           .where(
             and(
               eq(appointments.scheduleId, scheduleId),
-              eq(appointments.status, "token_started"),
+              inArray(appointments.status, ["token_started", "scheduled"]),
               sql`${appointments.tokenNumber} < ${tokenNumber}`
             )
           );
         const patientsAhead = aheadCount[0]?.count || 0;
         liveEstimatedStartTime = addMinutes(estimatedCurrentFinish, patientsAhead * avgConsultationTime);
       } else if (completedTokenCount > 0) {
-        // No one in progress but queue has already started (someone completed before this patient)
-        // This patient is next — count only token_started patients ahead
+        // No one in progress but queue has already started — count waiting patients ahead
         const aheadCount = await db
           .select({ count: sql<number>`COUNT(*)::integer` })
           .from(appointments)
           .where(
             and(
               eq(appointments.scheduleId, scheduleId),
-              eq(appointments.status, "token_started"),
+              inArray(appointments.status, ["token_started", "scheduled"]),
               sql`${appointments.tokenNumber} < ${tokenNumber}`
             )
           );

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -15,6 +15,7 @@ import {
   patientWallets,
   walletTransactions,
   appointmentRefunds,
+  tokenReservations,
   type User,
   type AttenderDoctor,
   type InsertUser,
@@ -31,9 +32,10 @@ import {
   type InsertAdminConfiguration,
   type PatientWallet,
   type WalletTransaction,
-  type AppointmentRefund
+  type AppointmentRefund,
+  type TokenReservation
 } from "@shared/schema";
-import { eq, or, and, sql, inArray, lte, gte, count, not, gt, lt, getTableColumns, isNotNull ,ne } from "drizzle-orm";
+import { eq, or, and, sql, inArray, lte, gte, count, not, gt, lt, getTableColumns, isNotNull, ne, max } from "drizzle-orm";
 import { db } from "./db";
 import session from "express-session";
 import connectPg from "connect-pg-simple";
@@ -238,6 +240,13 @@ export interface IStorage {
     currentToken: number,
     patientToken: number
   ): Promise<number>;
+
+  // Token reservation methods for walk-in flow
+  reserveNextToken(scheduleId: number, reservedByUserId: number): Promise<TokenReservation>;
+  confirmTokenReservation(reservationId: number, guestName: string, guestPhone: string | undefined): Promise<Appointment>;
+  cancelTokenReservation(reservationId: number, userId: number): Promise<void>;
+  expireStaleReservations(): Promise<void>;
+  getActiveReservationsForSchedule(scheduleId: number): Promise<TokenReservation[]>;
 
   updateDoctor(
     doctorId: number,
@@ -1627,9 +1636,11 @@ export class DatabaseStorage implements IStorage {
   }
 
   async getNextTokenNumber(doctorId: number, clinicId: number, scheduleId: number): Promise<number> {
-    // Add some debugging
     console.log(`Getting next token for doctor ${doctorId}, clinic ${clinicId}, schedule ${scheduleId}`);
-    
+
+    // Expire stale reservations first so they don't block online bookings
+    await this.expireStaleReservations();
+
     const [result] = await db
       .select({
         maxToken: sql<number>`COALESCE(MAX(token_number), 0)`,
@@ -1645,9 +1656,19 @@ export class DatabaseStorage implements IStorage {
         )
       );
 
-    const nextToken = (result?.maxToken || 0) + 1;
-    console.log(`Next token number will be: ${nextToken} (max found: ${result?.maxToken || 0})`);
-    
+    const maxAppt = result?.maxToken || 0;
+    // Account for pending, non-expired reservations so online bookings skip reserved tokens
+    const resResult = await db.select({ maxToken: max(tokenReservations.tokenNumber) })
+      .from(tokenReservations)
+      .where(and(
+        eq(tokenReservations.scheduleId, scheduleId),
+        eq(tokenReservations.status, "pending"),
+        gt(tokenReservations.expiresAt, new Date())
+      ));
+    const maxRes = resResult[0]?.maxToken || 0;
+    const nextToken = Math.max(maxAppt, maxRes) + 1;
+    console.log(`Next token number will be: ${nextToken} (maxAppt: ${maxAppt}, maxRes: ${maxRes})`);
+
     return nextToken;
   }
 
@@ -1703,7 +1724,8 @@ export class DatabaseStorage implements IStorage {
       throw new Error("You already have an appointment booked with this doctor for this schedule. Please check your existing appointments.");
     }
     
-    // Get current token count
+    // Get current token count — exclude cancelled appointments so cancellations
+    // don't eat into the doctor's capacity (only attended patients count)
     const [tokenCount] = await db
       .select({
         count: count(),
@@ -1713,10 +1735,11 @@ export class DatabaseStorage implements IStorage {
         and(
           eq(appointments.doctorId, appointment.doctorId),
           eq(appointments.clinicId, clinicId),
-          eq(appointments.scheduleId, schedule.id)
+          eq(appointments.scheduleId, schedule.id),
+          ne(appointments.status, "cancel")
         )
       );
-      
+
     // Check if token limit has been reached
     if (schedule.maxTokens !== null && tokenCount.count >= schedule.maxTokens) {
       throw new Error(`Maximum number of tokens (${schedule.maxTokens}) has been reached for this schedule`);
@@ -2945,8 +2968,19 @@ export class DatabaseStorage implements IStorage {
             ne(appointments.status, "cancel")
           )
         );
-      
-      return result?.count || 0;
+
+      // Also count pending non-expired reservations so the maxTokens check
+      // blocks online bookings while a walk-in token is reserved
+      const [resResult] = await db
+        .select({ count: count() })
+        .from(tokenReservations)
+        .where(and(
+          eq(tokenReservations.scheduleId, scheduleId),
+          eq(tokenReservations.status, "pending"),
+          gt(tokenReservations.expiresAt, new Date())
+        ));
+
+      return (result?.count || 0) + (resResult?.count || 0);
     } catch (error) {
       console.error('Error counting appointments:', error);
       throw error;
@@ -3077,7 +3111,8 @@ export class DatabaseStorage implements IStorage {
       scheduleId = schedule.id;
     }
     
-    // Get current token count
+    // Get current token count — exclude cancelled appointments so cancellations
+    // don't eat into the doctor's capacity (only attended patients count)
     const [tokenCount] = await db
       .select({
         count: count(),
@@ -3087,10 +3122,11 @@ export class DatabaseStorage implements IStorage {
         and(
           eq(appointments.doctorId, appointment.doctorId),
           eq(appointments.clinicId, appointment.clinicId),
-          eq(appointments.scheduleId, scheduleId)
+          eq(appointments.scheduleId, scheduleId),
+          ne(appointments.status, "cancel")
         )
       );
-      
+
     // Get the schedule to check token limit
     const [scheduleData] = await db
       .select()
@@ -4894,7 +4930,7 @@ export class DatabaseStorage implements IStorage {
   async markAppointmentAsRefunded(appointmentId: number, refundAmount: number): Promise<void> {
     try {
       console.log(`Marking appointment ${appointmentId} as refunded with amount ${refundAmount}`);
-      
+
       await db
         .update(appointments)
         .set({
@@ -4903,12 +4939,117 @@ export class DatabaseStorage implements IStorage {
           refundedAt: sql`CURRENT_TIMESTAMP`
         })
         .where(eq(appointments.id, appointmentId));
-      
+
       console.log(`Successfully marked appointment ${appointmentId} as refunded`);
     } catch (error) {
       console.error(`Error marking appointment ${appointmentId} as refunded:`, error);
       throw error;
     }
+  }
+
+  // --- Token Reservation Methods ---
+
+  async expireStaleReservations(): Promise<void> {
+    await db.update(tokenReservations)
+      .set({ status: "expired" })
+      .where(and(eq(tokenReservations.status, "pending"), lt(tokenReservations.expiresAt, new Date())));
+  }
+
+  async reserveNextToken(scheduleId: number, reservedByUserId: number): Promise<TokenReservation> {
+    // 1. Expire any old reservations first
+    await this.expireStaleReservations();
+
+    // 2. Get max token from appointments (non-cancelled)
+    const apptResult = await db.select({ maxToken: max(appointments.tokenNumber) })
+      .from(appointments)
+      .where(and(eq(appointments.scheduleId, scheduleId), ne(appointments.status, "cancel")));
+
+    // 3. Get max token from active reservations on this schedule
+    const resResult = await db.select({ maxToken: max(tokenReservations.tokenNumber) })
+      .from(tokenReservations)
+      .where(and(eq(tokenReservations.scheduleId, scheduleId), eq(tokenReservations.status, "pending")));
+
+    const maxAppt = apptResult[0]?.maxToken || 0;
+    const maxRes = resResult[0]?.maxToken || 0;
+    const nextToken = Math.max(maxAppt, maxRes) + 1;
+
+    // 4. Create reservation with 5-minute expiry
+    const expiresAt = new Date(Date.now() + 5 * 60 * 1000);
+    const [reservation] = await db.insert(tokenReservations).values({
+      scheduleId,
+      tokenNumber: nextToken,
+      reservedByUserId,
+      status: "pending",
+      expiresAt,
+    }).returning();
+
+    return reservation;
+  }
+
+  async confirmTokenReservation(reservationId: number, guestName: string, guestPhone: string | undefined): Promise<Appointment> {
+    // 1. Get the reservation
+    const [reservation] = await db.select().from(tokenReservations)
+      .where(and(eq(tokenReservations.id, reservationId), eq(tokenReservations.status, "pending")));
+
+    if (!reservation) throw new Error("Reservation not found or already expired");
+    if (new Date() > reservation.expiresAt) {
+      await db.update(tokenReservations).set({ status: "expired" }).where(eq(tokenReservations.id, reservationId));
+      throw new Error("Reservation has expired. Please reserve again.");
+    }
+
+    // 2. Get schedule details
+    const [schedule] = await db.select().from(doctorSchedules).where(eq(doctorSchedules.id, reservation.scheduleId));
+    if (!schedule) throw new Error("Schedule not found");
+
+    // 3. Check if reserved token was stolen by a race condition — reassign if needed
+    const [collision] = await db.select().from(appointments)
+      .where(and(
+        eq(appointments.scheduleId, reservation.scheduleId),
+        eq(appointments.tokenNumber, reservation.tokenNumber),
+        ne(appointments.status, "cancel")
+      ));
+
+    let finalTokenNumber = reservation.tokenNumber;
+    if (collision) {
+      // Token was taken — recalculate next available
+      const [maxResult] = await db.select({ maxToken: sql<number>`COALESCE(MAX(token_number), 0)` })
+        .from(appointments)
+        .where(and(eq(appointments.scheduleId, reservation.scheduleId), ne(appointments.status, "cancel")));
+      finalTokenNumber = (maxResult?.maxToken || 0) + 1;
+    }
+
+    // 4. Create the appointment with the final token number
+    const [appointment] = await db.insert(appointments).values({
+      doctorId: schedule.doctorId,
+      clinicId: schedule.clinicId,
+      scheduleId: reservation.scheduleId,
+      date: new Date(schedule.date + 'T00:00:00.000Z'),
+      tokenNumber: finalTokenNumber,
+      guestName,
+      guestPhone: guestPhone || null,
+      isWalkIn: true,
+      status: "token_started",
+      isPaid: false,
+      isRefundEligible: false,
+      hasBeenRefunded: false,
+    }).returning();
+
+    // 5. Mark reservation as confirmed
+    await db.update(tokenReservations).set({ status: "confirmed" }).where(eq(tokenReservations.id, reservationId));
+
+    return appointment;
+  }
+
+  async cancelTokenReservation(reservationId: number, userId: number): Promise<void> {
+    await db.update(tokenReservations)
+      .set({ status: "cancelled" })
+      .where(and(eq(tokenReservations.id, reservationId), eq(tokenReservations.reservedByUserId, userId)));
+  }
+
+  async getActiveReservationsForSchedule(scheduleId: number): Promise<TokenReservation[]> {
+    await this.expireStaleReservations();
+    return db.select().from(tokenReservations)
+      .where(and(eq(tokenReservations.scheduleId, scheduleId), eq(tokenReservations.status, "pending")));
   }
 }
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1745,12 +1745,34 @@ export class DatabaseStorage implements IStorage {
       throw new Error(`Maximum number of tokens (${schedule.maxTokens}) has been reached for this schedule`);
     }
     
-    // Use provided tokenNumber or generate a new one
-    const tokenNumber = appointment.tokenNumber ?? await this.getNextTokenNumber(
+    // Generate next token and guard against race condition with walk-in reservations.
+    // After getNextTokenNumber runs, a pending reservation for that exact token
+    // may have just committed — check and skip past it if so.
+    let tokenNumber = appointment.tokenNumber ?? await this.getNextTokenNumber(
       appointment.doctorId,
       clinicId,
       schedule.id
     );
+    const [reservationConflict] = await db
+      .select({ tokenNumber: tokenReservations.tokenNumber })
+      .from(tokenReservations)
+      .where(and(
+        eq(tokenReservations.scheduleId, schedule.id),
+        eq(tokenReservations.tokenNumber, tokenNumber),
+        eq(tokenReservations.status, "pending"),
+        gt(tokenReservations.expiresAt, new Date())
+      ));
+    if (reservationConflict) {
+      // A reservation was created between our getNextTokenNumber call and now — skip past it
+      const [maxResult] = await db.select({ maxToken: max(tokenReservations.tokenNumber) })
+        .from(tokenReservations)
+        .where(and(
+          eq(tokenReservations.scheduleId, schedule.id),
+          eq(tokenReservations.status, "pending"),
+          gt(tokenReservations.expiresAt, new Date())
+        ));
+      tokenNumber = (maxResult?.maxToken || tokenNumber) + 1;
+    }
 
     const [created] = await db
       .insert(appointments)
@@ -2557,10 +2579,20 @@ export class DatabaseStorage implements IStorage {
         };
       }
 
-      // If no token_started appointments, find the last appointment in any other state
+      // If no token_started appointments, check if all remaining are unstarted (scheduled/cancel/no_show)
       const lastAppointment = todayAppointments[todayAppointments.length - 1];
-      
+
       console.log('Last appointment in any state:', lastAppointment);
+
+      // If all appointments are in a non-active state, queue hasn't started yet
+      const inactiveStatuses = ['scheduled', 'cancel', 'no_show'];
+      if (inactiveStatuses.includes(lastAppointment.status)) {
+        return {
+          currentToken: 0,
+          status: 'not_started' as any,
+        };
+      }
+
       return {
         currentToken: lastAppointment.tokenNumber,
         status: lastAppointment.status as any,
@@ -5028,7 +5060,7 @@ export class DatabaseStorage implements IStorage {
       guestName,
       guestPhone: guestPhone || null,
       isWalkIn: true,
-      status: "token_started",
+      status: "scheduled",
       isPaid: false,
       isRefundEligible: false,
       hasBeenRefunded: false,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -276,6 +276,16 @@ export const appointmentRefunds = pgTable("appointment_refunds", {
   createdAt: timestamp("created_at").default(sql`CURRENT_TIMESTAMP`),
 });
 
+export const tokenReservations = pgTable("token_reservations", {
+  id: serial("id").primaryKey(),
+  scheduleId: integer("schedule_id").notNull().references(() => doctorSchedules.id),
+  tokenNumber: integer("token_number").notNull(),
+  reservedByUserId: integer("reserved_by_user_id").notNull().references(() => users.id),
+  status: varchar("status", { length: 20 }).default("pending"), // pending | confirmed | cancelled | expired
+  expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
+});
+
 // Define relations
 export const usersRelations = relations(users, ({ one, many }) => ({
   clinic: one(clinics, {
@@ -545,6 +555,9 @@ export type WalletTransaction = typeof walletTransactions.$inferSelect;
 export type InsertWalletTransaction = z.infer<typeof insertWalletTransactionSchema>;
 export type AppointmentRefund = typeof appointmentRefunds.$inferSelect;
 export type InsertAppointmentRefund = z.infer<typeof insertAppointmentRefundSchema>;
+
+export type TokenReservation = typeof tokenReservations.$inferSelect;
+export type InsertTokenReservation = typeof tokenReservations.$inferInsert;
 
 export const specialties = [
   "Cardiologist",


### PR DESCRIPTION
## Summary

- **Walk-in 2-step reservation flow**: Attender clicks "+ New Walk-in" → token is reserved for 5 minutes (held against online bookings) → attender fills patient details → confirmed as appointment
- **Race condition protection**: Reserved tokens are blocked from online booking; post-assignment double-check reassigns if a collision still occurs
- **Walk-in status fix**: Walk-in appointments correctly get `scheduled` status (not `token_started`)
- **ETA fixes**: Completed tokens now show actual end time; walk-in (`scheduled`) patients are counted in the ahead queue so each token is offset by 15 min correctly
- **Progress bar fix**: Unstarted schedules (all `scheduled`/`cancel`/`no_show`) return `currentToken=0` instead of the last token number (which caused a full 100% bar)
- **Doctor arrival banner**: Booking history now fetches doctor arrival for all active statuses, not just `token_started`, so walk-in patients see the "Doctor has arrived" message

## New endpoints
- `POST /api/schedules/:scheduleId/reserve-token` — reserve next available token (5-min hold)
- `POST /api/schedules/:scheduleId/confirm-walkin` — confirm reservation with patient details
- `DELETE /api/schedules/:scheduleId/reservation/:reservationId` — cancel a pending reservation

## Test plan
- [ ] Book online as patient → walk-in reservation holds next token; online booking gets token after the reserved one
- [ ] Let 5-min timer expire with dialog open → reservation auto-cancels in DB, dialog closes
- [ ] Close walk-in dialog mid-fill → reservation is cancelled
- [ ] Complete a walk-in → status shows "Scheduled" (not "Token Started") in booking history
- [ ] Doctor marked arrived → "Your doctor has arrived" banner appears for walk-in patients
- [ ] Progress bar starts empty for a new schedule with no active tokens
- [ ] ETA for Token N+1 (walk-in) is exactly 15 min after Token N

🤖 Generated with [Claude Code](https://claude.com/claude-code)