### PR TITLE
feat: User profile page and cancellation restriction after doctor arrival

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -43,6 +43,7 @@ import FAQs from "@/pages/help/FAQs";
 import ContactUs from "@/pages/help/ContactUs";
 import MapPage from "@/pages/map-page";
 import LandingPage from "@/pages/landing-page";
+import UserProfile from "@/pages/user-profile";
 
 // Wrap DoctorManagementPage with ProtectedRoute
 const ProtectedDoctorManagement = () => (
@@ -131,6 +132,7 @@ function Router() {
       <Route path="/patient/favorites" component={PatientFavorites} />
       <Route path="/map" component={MapPage} />
       <Route path="/patient/wallet" component={PatientWallet} />
+      <Route path="/profile" component={UserProfile} />
       
       {/* Policy and Help Pages */}
       <Route path="/policies/privacy-policy" component={PrivacyPolicy} />

--- a/client/src/components/nav-header.tsx
+++ b/client/src/components/nav-header.tsx
@@ -118,9 +118,11 @@ export function NavHeader() {
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
-                  <DropdownMenuItem className="gap-2">
-                    <User size={16} />
-                    <span>{user.name}</span>
+                  <DropdownMenuItem asChild>
+                    <Link href="/profile" className="gap-2">
+                      <User size={16} />
+                      <span>My Profile</span>
+                    </Link>
                   </DropdownMenuItem>
                   {!isAttenderDashboard && !isClinicAdmin && !isSuperAdmin && (
                     <DropdownMenuItem asChild>

--- a/client/src/pages/booking-history.tsx
+++ b/client/src/pages/booking-history.tsx
@@ -405,8 +405,15 @@ export default function BookingHistoryPage() {
                                   </div>
                                 )}
 
-                                {/* Patient self-cancellation — only for token_started */}
-                                {appointment.status === "token_started" && (
+                                {/* Doctor arrived — cancellation blocked */}
+                                {appointment.status === "token_started" && doctorHasArrived && (
+                                  <div className="mt-3 pt-3 border-t text-sm text-center text-muted-foreground">
+                                    Cancellation unavailable — doctor has arrived
+                                  </div>
+                                )}
+
+                                {/* Patient self-cancellation — only before doctor arrives */}
+                                {appointment.status === "token_started" && !doctorHasArrived && (
                                   <div className="mt-3 pt-3 border-t">
                                     <Dialog open={cancellingId === appointment.id} onOpenChange={(open) => {
                                       if (!open) { setCancellingId(null); setCancelReason(''); }

--- a/client/src/pages/user-profile.tsx
+++ b/client/src/pages/user-profile.tsx
@@ -1,0 +1,255 @@
+// User profile page — view and edit personal details for all roles
+import React, { useEffect } from "react";
+import { useAuth } from "@/hooks/use-auth";
+import { NavHeader } from "@/components/nav-header";
+import PatientFooter from "@/components/PatientFooter";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { useToast } from "@/hooks/use-toast";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useLocation } from "wouter";
+import { ArrowLeft, User, Phone, Mail, MapPin, Stethoscope, Save } from "lucide-react";
+import { useForm } from "react-hook-form";
+
+interface ProfileFormValues {
+  name: string;
+  email: string;
+  phone: string;
+  address: string;
+  city: string;
+  state: string;
+  zipCode: string;
+  specialty: string;
+  bio: string;
+}
+
+export default function UserProfile() {
+  const { user } = useAuth();
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [, setLocation] = useLocation();
+
+  const isDoctor = user?.role === "doctor";
+  const isAttender = user?.role === "attender";
+  const showProfessional = isDoctor || isAttender;
+
+  const { register, handleSubmit, reset, formState: { isDirty } } = useForm<ProfileFormValues>({
+    defaultValues: {
+      name: "",
+      email: "",
+      phone: "",
+      address: "",
+      city: "",
+      state: "",
+      zipCode: "",
+      specialty: "",
+      bio: "",
+    },
+  });
+
+  useEffect(() => {
+    if (user) {
+      reset({
+        name: user.name || "",
+        email: user.email || "",
+        phone: user.phone || "",
+        address: user.address || "",
+        city: user.city || "",
+        state: user.state || "",
+        zipCode: user.zipCode || "",
+        specialty: user.specialty || "",
+        bio: user.bio || "",
+      });
+    }
+  }, [user, reset]);
+
+  const updateMutation = useMutation({
+    mutationFn: async (data: ProfileFormValues) => {
+      const res = await fetch("/api/user", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.message || "Failed to update profile");
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/user"] });
+      toast({ title: "Profile updated successfully" });
+    },
+    onError: (err: Error) => {
+      toast({ title: "Update failed", description: err.message, variant: "destructive" });
+    },
+  });
+
+  const onSubmit = (data: ProfileFormValues) => {
+    updateMutation.mutate(data);
+  };
+
+  const initials = user?.name
+    ? user.name.split(" ").map((n) => n[0]).join("").toUpperCase()
+    : "?";
+
+  const roleLabel: Record<string, string> = {
+    patient: "Patient",
+    doctor: "Doctor",
+    attender: "Attender",
+    hospital_admin: "Hospital Admin",
+    clinic_admin: "Clinic Admin",
+    super_admin: "Super Admin",
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col bg-gray-50">
+      <NavHeader />
+
+      <div className="flex-1">
+        <div className="container mx-auto py-8 px-4 max-w-2xl">
+          {/* Header */}
+          <div className="flex items-center gap-4 mb-6">
+            <Button variant="ghost" size="sm" onClick={() => setLocation("/")} className="gap-2">
+              <ArrowLeft className="h-4 w-4" />
+              Back
+            </Button>
+            <h1 className="text-2xl font-bold">My Profile</h1>
+          </div>
+
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+            {/* Avatar + role card */}
+            <Card>
+              <CardContent className="pt-6">
+                <div className="flex items-center gap-5">
+                  <Avatar className="h-20 w-20 text-xl">
+                    <AvatarImage src={user?.imageUrl || undefined} alt={user?.name} />
+                    <AvatarFallback className="bg-primary text-primary-foreground text-xl">
+                      {initials}
+                    </AvatarFallback>
+                  </Avatar>
+                  <div>
+                    <p className="text-xl font-semibold">{user?.name}</p>
+                    <p className="text-sm text-muted-foreground">@{user?.username}</p>
+                    <Badge variant="secondary" className="mt-1">
+                      {roleLabel[user?.role || ""] || user?.role}
+                    </Badge>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Personal Information */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <User className="h-4 w-4" />
+                  Personal Information
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="name">Full Name</Label>
+                  <Input id="name" {...register("name")} placeholder="Your full name" />
+                </div>
+
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="email" className="flex items-center gap-1">
+                      <Mail className="h-3 w-3" /> Email
+                    </Label>
+                    <Input id="email" type="email" {...register("email")} placeholder="email@example.com" />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="phone" className="flex items-center gap-1">
+                      <Phone className="h-3 w-3" /> Phone
+                    </Label>
+                    <Input id="phone" {...register("phone")} placeholder="+91 XXXXX XXXXX" />
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Address */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <MapPin className="h-4 w-4" />
+                  Address
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="address">Street Address</Label>
+                  <Input id="address" {...register("address")} placeholder="123 Main Street" />
+                </div>
+                <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+                  <div className="space-y-2 col-span-2 sm:col-span-1">
+                    <Label htmlFor="city">City</Label>
+                    <Input id="city" {...register("city")} placeholder="Chennai" />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="state">State</Label>
+                    <Input id="state" {...register("state")} placeholder="Tamil Nadu" />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="zipCode">PIN Code</Label>
+                    <Input id="zipCode" {...register("zipCode")} placeholder="600001" />
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Professional Info — doctors and attenders only */}
+            {showProfessional && (
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-base">
+                    <Stethoscope className="h-4 w-4" />
+                    Professional Information
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="specialty">Specialty</Label>
+                    <Input id="specialty" {...register("specialty")} placeholder="e.g. General Medicine" />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="bio">Bio</Label>
+                    <Textarea
+                      id="bio"
+                      {...register("bio")}
+                      placeholder="Brief professional background..."
+                      rows={3}
+                    />
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+
+            <Separator />
+
+            <div className="flex justify-end">
+              <Button
+                type="submit"
+                disabled={updateMutation.isPending || !isDirty}
+                className="gap-2 min-w-[120px]"
+              >
+                <Save className="h-4 w-4" />
+                {updateMutation.isPending ? "Saving..." : "Save Changes"}
+              </Button>
+            </div>
+          </form>
+        </div>
+      </div>
+
+      <PatientFooter />
+    </div>
+  );
+}

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -190,6 +190,26 @@ export function setupAuth(app: Express) {
     res.json(req.user);
   });
 
+  app.patch("/api/user", async (req, res) => {
+    if (!req.isAuthenticated()) return res.sendStatus(401);
+    try {
+      const allowed = ["name", "email", "phone", "address", "city", "state", "zipCode", "imageUrl", "bio", "specialty"];
+      const updates: Record<string, string> = {};
+      for (const field of allowed) {
+        if (req.body[field] !== undefined) updates[field] = req.body[field];
+      }
+      if (Object.keys(updates).length === 0) {
+        return res.status(400).json({ message: "No valid fields to update" });
+      }
+      const updatedUser = await storage.updateUser(req.user.id, updates);
+      const { password: _pw, ...safeUser } = updatedUser;
+      res.json(safeUser);
+    } catch (error) {
+      console.error("Error updating profile:", error);
+      res.status(500).json({ message: "Failed to update profile" });
+    }
+  });
+
   // OTP Authentication endpoints
   app.post("/api/auth/request-otp", async (req, res) => {
     try {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -675,6 +675,16 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(400).json({ message: `Cannot cancel appointment with status: ${appointment.status}` });
       }
 
+      // Block cancellation once the doctor has arrived at the clinic
+      const arrivalStatus = await storage.getDoctorArrivalStatus(
+        appointment.doctorId,
+        appointment.clinicId,
+        new Date()
+      );
+      if (arrivalStatus?.hasArrived) {
+        return res.status(400).json({ message: 'Cancellation is not allowed after the doctor has arrived at the clinic.' });
+      }
+
       await storage.updateAppointmentStatus(appointmentId, 'cancel', reason.trim());
 
       // Process refund if eligible


### PR DESCRIPTION
## Summary

- **User profile page**: New `/profile` route for all roles — view and edit personal details (name, email, phone, address). Doctors/attenders also see specialty and bio fields. Accessible via "My Profile" in the avatar dropdown.
- **PATCH /api/user** endpoint: Authenticated users can update their own profile fields. Password, role and username are protected from change via this endpoint.
- **Nav dropdown cleanup**: Removed duplicate name row; "My Profile" is now the first dropdown item.
- **Cancellation blocked after doctor arrives**: Patient cannot cancel their appointment once the doctor has marked arrival. Server enforces this with a 400 response; client replaces the Cancel button with an explanatory notice.

## Test plan
- [ ] Log in as any role → click avatar → "My Profile" appears as first item
- [ ] Edit name/email/phone on profile page → save → changes persist on refresh
- [ ] Doctor/attender sees specialty and bio fields; patient does not
- [ ] Book an appointment → mark doctor as arrived → patient's Cancel button replaced with notice
- [ ] Attempt to call `PATCH /api/appointments/:id/cancel-patient` directly after doctor arrives → receives 400 error
- [ ] Cancel appointment before doctor arrives → works normally with full refund

🤖 Generated with [Claude Code](https://claude.com/claude-code)