### PR TITLE
feat: book for someone else

### DIFF
--- a/client/src/pages/attender-dashboard.tsx
+++ b/client/src/pages/attender-dashboard.tsx
@@ -1005,6 +1005,14 @@ export default function AttenderDashboard() {
                                                         <div className="font-medium">{appointment.guestName}</div>
                                                         <Badge variant="outline" className="mt-1">Walk-in</Badge>
                                                       </div>
+                                                    ) : appointment.isOnBehalf ? (
+                                                      <div>
+                                                        <div className="font-medium">{appointment.guestName}</div>
+                                                        <Badge variant="secondary" className="mt-1">On behalf</Badge>
+                                                        {appointment.patient?.name && (
+                                                          <div className="text-xs text-muted-foreground mt-1">by {appointment.patient.name}</div>
+                                                        )}
+                                                      </div>
                                                     ) : (
                                                       <div className="font-medium">{appointment.patient?.name}</div>
                                                     )}

--- a/client/src/pages/booking-history.tsx
+++ b/client/src/pages/booking-history.tsx
@@ -309,6 +309,11 @@ export default function BookingHistoryPage() {
                                   <p className="text-sm text-muted-foreground">
                                     {appointment.doctor.specialty}
                                   </p>
+                                  {appointment.isOnBehalf && appointment.guestName && (
+                                    <p className="text-sm text-blue-600 font-medium mt-1">
+                                      Patient: {appointment.guestName}
+                                    </p>
+                                  )}
                                 </div>
                                 <AppointmentStatusBadge status={appointment.status} />
                               </div>

--- a/client/src/pages/patient-booking-page.tsx
+++ b/client/src/pages/patient-booking-page.tsx
@@ -11,11 +11,15 @@ import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
 import { format, startOfDay } from "date-fns";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { AlertCircle, Clock, UserCheck, UserX, Building, Calendar as CalendarIcon } from "lucide-react";
+import { AlertCircle, Clock, UserCheck, UserX, Building, Calendar as CalendarIcon, Users } from "lucide-react";
 import { queryClient, apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import { NavigationButtons } from "@/components/navigation-buttons";
 import { invalidateWalletQueries } from "@/utils/wallet-utils";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
 
 // Define types
 type Clinic = {
@@ -54,6 +58,11 @@ export default function PatientBookingPage() {
   const { toast } = useToast();
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
   const [selectedSchedule, setSelectedSchedule] = useState<DoctorSchedule | null>(null);
+  const [showBookingDialog, setShowBookingDialog] = useState(false);
+  const [pendingSchedule, setPendingSchedule] = useState<DoctorSchedule | null>(null);
+  const [isOnBehalf, setIsOnBehalf] = useState(false);
+  const [beneficiaryName, setBeneficiaryName] = useState("");
+  const [beneficiaryPhone, setBeneficiaryPhone] = useState("");
 
   const { data: doctor, isLoading: isLoadingDoctor } = useQuery<User>({
     queryKey: [`/api/doctors/${doctorId}`],
@@ -97,7 +106,7 @@ export default function PatientBookingPage() {
   };
 
   const bookAppointmentMutation = useMutation({
-    mutationFn: async (schedule: DoctorSchedule) => {
+    mutationFn: async ({ schedule, onBehalf, guestName, guestPhone }: { schedule: DoctorSchedule; onBehalf: boolean; guestName?: string; guestPhone?: string }) => {
       if (!schedule) throw new Error("Please select a clinic schedule");
 
       // Create appointment date by combining selected date with schedule start time
@@ -110,6 +119,9 @@ export default function PatientBookingPage() {
         date: appointmentDate.toISOString(),
         clinicId: schedule.clinicId,
         scheduleId: schedule.id,
+        isOnBehalf: onBehalf,
+        guestName: onBehalf ? guestName : undefined,
+        guestPhone: onBehalf ? guestPhone : undefined,
       });
       return res.json();
     },
@@ -130,9 +142,10 @@ export default function PatientBookingPage() {
       const etaText = response?.estimatedStartTime
         ? ` Your estimated time: ${format(new Date(response.estimatedStartTime), "h:mm a")}.`
         : "";
+      const onBehalfText = response?.guestName ? ` Booked for ${response.guestName}.` : "";
       toast({
         title: "Appointment Booked Successfully! ✅",
-        description: `Your appointment has been confirmed.${etaText}`,
+        description: `Your appointment has been confirmed.${onBehalfText}${etaText}`,
       });
     },
     onError: (error) => {
@@ -145,9 +158,8 @@ export default function PatientBookingPage() {
     },
   });
 
-  // Direct booking function
+  // Open dialog before booking
   const bookAppointment = (schedule: DoctorSchedule) => {
-    // Check for duplicate booking first
     if (hasExistingAppointment(schedule.id)) {
       toast({
         title: "Appointment Already Exists",
@@ -156,8 +168,27 @@ export default function PatientBookingPage() {
       });
       return;
     }
-    
-    bookAppointmentMutation.mutate(schedule);
+    setPendingSchedule(schedule);
+    setIsOnBehalf(false);
+    setBeneficiaryName("");
+    setBeneficiaryPhone("");
+    setShowBookingDialog(true);
+  };
+
+  const confirmBooking = () => {
+    if (!pendingSchedule) return;
+    if (isOnBehalf) {
+      if (!beneficiaryName.trim()) {
+        toast({ title: "Patient name is required", variant: "destructive" });
+        return;
+      }
+      if (!/^\d{10}$/.test(beneficiaryPhone.trim())) {
+        toast({ title: "Enter a valid 10-digit phone number", variant: "destructive" });
+        return;
+      }
+    }
+    setShowBookingDialog(false);
+    bookAppointmentMutation.mutate({ schedule: pendingSchedule, onBehalf: isOnBehalf, guestName: beneficiaryName, guestPhone: beneficiaryPhone });
   };
 
   // Add this useEffect near the top of the component
@@ -365,6 +396,57 @@ export default function PatientBookingPage() {
           </Card>
         </div>
       </main>
+
+      <Dialog open={showBookingDialog} onOpenChange={setShowBookingDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Confirm Booking</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            <div className="flex items-center gap-3">
+              <Checkbox
+                id="onBehalf"
+                checked={isOnBehalf}
+                onCheckedChange={(v) => setIsOnBehalf(!!v)}
+              />
+              <Label htmlFor="onBehalf" className="flex items-center gap-2 cursor-pointer">
+                <Users className="h-4 w-4 text-muted-foreground" />
+                Booking for someone else?
+              </Label>
+            </div>
+            {isOnBehalf && (
+              <div className="space-y-3 pl-7">
+                <div>
+                  <Label htmlFor="beneficiaryName">Patient Name</Label>
+                  <Input
+                    id="beneficiaryName"
+                    placeholder="Enter patient's full name"
+                    value={beneficiaryName}
+                    onChange={(e) => setBeneficiaryName(e.target.value)}
+                    className="mt-1"
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="beneficiaryPhone">Patient Phone</Label>
+                  <Input
+                    id="beneficiaryPhone"
+                    placeholder="10-digit mobile number"
+                    value={beneficiaryPhone}
+                    onChange={(e) => setBeneficiaryPhone(e.target.value)}
+                    className="mt-1"
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowBookingDialog(false)}>Cancel</Button>
+            <Button onClick={confirmBooking} disabled={bookAppointmentMutation.isPending}>
+              {bookAppointmentMutation.isPending ? "Booking..." : "Confirm Booking"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/client/src/pages/patient-clinic-details.tsx
+++ b/client/src/pages/patient-clinic-details.tsx
@@ -4,9 +4,19 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { CalendarDays, Search, Clock, Calendar, Loader2, Star, StarOff, Navigation } from "lucide-react";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import { CalendarDays, Search, Clock, Calendar, Loader2, Star, StarOff, Navigation, Users } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from "@/components/ui/dialog";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
@@ -52,6 +62,11 @@ export default function PatientClinicDetails() {
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedDoctor, setSelectedDoctor] = useState<string | null>(null);
   const [selectedSlot, setSelectedSlot] = useState<{ day: string, time: string } | null>(null);
+  const [showBookingDialog, setShowBookingDialog] = useState(false);
+  const [pendingBookingData, setPendingBookingData] = useState<any>(null);
+  const [isOnBehalf, setIsOnBehalf] = useState(false);
+  const [beneficiaryName, setBeneficiaryName] = useState("");
+  const [beneficiaryPhone, setBeneficiaryPhone] = useState("");
   
   // Auto-select doctor from URL parameter when doctors data loads
   useEffect(() => {
@@ -93,7 +108,7 @@ export default function PatientClinicDetails() {
   
   // Booking mutation for appointment creation
   const bookingMutation = useMutation({
-    mutationFn: async (appointmentData: { doctorId: number; clinicId: number; scheduleId: number; date: string; time: string }) => {
+    mutationFn: async (appointmentData: { doctorId: number; clinicId: number; scheduleId: number; date: string; time: string; isOnBehalf?: boolean; guestName?: string; guestPhone?: string }) => {
       if (!user) {
         throw new Error("You must be logged in to book an appointment");
       }
@@ -142,7 +157,10 @@ export default function PatientClinicDetails() {
           scheduleId: appointmentData.scheduleId,
           date: appointmentDate.toISOString(),
           tokenNumber: tokenNumber,
-          status: "scheduled"
+          status: "scheduled",
+          isOnBehalf: appointmentData.isOnBehalf || false,
+          guestName: appointmentData.guestName || null,
+          guestPhone: appointmentData.guestPhone || null,
         })
       });
       
@@ -343,13 +361,17 @@ export default function PatientClinicDetails() {
         time: selectedSlot.time
       });
       
-      bookingMutation.mutate({
+      setPendingBookingData({
         doctorId: doctorIdNum,
         clinicId: clinicIdNum,
         scheduleId: scheduleIdNum,
         date: appointmentDate.toISOString(),
-        time: selectedSlot.time
+        time: selectedSlot.time,
       });
+      setIsOnBehalf(false);
+      setBeneficiaryName("");
+      setBeneficiaryPhone("");
+      setShowBookingDialog(true);
     } catch (error) {
       toast({
         title: "Error",
@@ -358,6 +380,26 @@ export default function PatientClinicDetails() {
       });
       console.error("Date parsing error:", error);
     }
+  };
+
+  const confirmBooking = () => {
+    if (isOnBehalf) {
+      if (!beneficiaryName.trim()) {
+        toast({ title: "Error", description: "Patient name is required", variant: "destructive" });
+        return;
+      }
+      if (!/^\d{10}$/.test(beneficiaryPhone.trim())) {
+        toast({ title: "Error", description: "Enter a valid 10-digit phone number", variant: "destructive" });
+        return;
+      }
+    }
+    setShowBookingDialog(false);
+    bookingMutation.mutate({
+      ...pendingBookingData,
+      isOnBehalf,
+      guestName: isOnBehalf ? beneficiaryName.trim() : undefined,
+      guestPhone: isOnBehalf ? beneficiaryPhone.trim() : undefined,
+    });
   };
 
   // Check for schedule status changes and show notifications
@@ -860,6 +902,70 @@ export default function PatientClinicDetails() {
         </div>
       </div>
       </div>
+
+      {/* Booking confirmation dialog with "Book for someone else" toggle */}
+      <Dialog open={showBookingDialog} onOpenChange={(open) => { if (!open) setShowBookingDialog(false); }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Confirm Appointment</DialogTitle>
+            <DialogDescription>
+              ₹21 will be deducted from your wallet.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-2">
+            <div className="flex items-center gap-3">
+              <Checkbox
+                id="onBehalf"
+                checked={isOnBehalf}
+                onCheckedChange={(v) => setIsOnBehalf(!!v)}
+              />
+              <Label htmlFor="onBehalf" className="flex items-center gap-2 cursor-pointer">
+                <Users className="h-4 w-4 text-muted-foreground" />
+                Booking for someone else
+              </Label>
+            </div>
+
+            {isOnBehalf && (
+              <div className="space-y-3 pl-7 border-l-2 border-primary/20 ml-1">
+                <div className="space-y-1">
+                  <Label htmlFor="beneficiaryName">Patient Name <span className="text-red-500">*</span></Label>
+                  <Input
+                    id="beneficiaryName"
+                    value={beneficiaryName}
+                    onChange={(e) => setBeneficiaryName(e.target.value)}
+                    placeholder="Full name of the patient"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="beneficiaryPhone">Patient Phone <span className="text-red-500">*</span></Label>
+                  <Input
+                    id="beneficiaryPhone"
+                    value={beneficiaryPhone}
+                    onChange={(e) => setBeneficiaryPhone(e.target.value)}
+                    placeholder="10-digit mobile number"
+                    maxLength={10}
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowBookingDialog(false)}>
+              Cancel
+            </Button>
+            <Button onClick={confirmBooking} disabled={bookingMutation.isPending}>
+              {bookingMutation.isPending ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Calendar className="mr-2 h-4 w-4" />
+              )}
+              Confirm Booking
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/docs/user-stories/book-for-someone-else.md
+++ b/docs/user-stories/book-for-someone-else.md
@@ -1,0 +1,190 @@
+# User Story: Book Appointment for Someone Else
+
+## Story
+
+**As a** registered patient,  
+**I want to** book an appointment on behalf of a family member or friend,  
+**So that** their name appears on the token at the clinic even though I am the one booking and paying.
+
+---
+
+## Background / Motivation
+
+A user in Chennai wants to book an appointment for their uncle in Coimbatore. Today the app has no location restriction — they can find the clinic and book — but the appointment is always registered under the booker's own name. The attender sees the booker's name on the token, not the actual patient's name, causing confusion at the clinic.
+
+This feature allows the booker to enter the actual patient's name and phone number at booking time so the token shows the right person.
+
+---
+
+## Personas
+
+| Persona | Description |
+|---|---|
+| **Booker** | The logged-in user who initiates and pays for the booking (e.g., person in Chennai) |
+| **Beneficiary** | The actual patient who will attend the appointment (e.g., uncle in Coimbatore) |
+| **Attender** | Clinic staff who manages the token queue and calls patients |
+
+---
+
+## Acceptance Criteria
+
+### AC1 — Booking form has a "Book for someone else" toggle
+- When booking an appointment, the patient sees a checkbox/toggle: **"This appointment is for someone else"**
+- By default it is **off** (booking for self)
+- When toggled **on**, two new required fields appear:
+  - **Patient Name** (text, required)
+  - **Patient Phone** (10-digit, required)
+
+### AC2 — Booker's wallet is charged, not beneficiary's
+- The ₹21 consultation fee is always deducted from the **booker's wallet**
+- The beneficiary does not need to have an account on the app
+
+### AC3 — Token shows beneficiary's name at clinic
+- On the attender dashboard, the token row shows the **beneficiary's name** (not the booker's)
+- A **"On behalf"** badge is shown alongside the name (similar to the "Walk-in" badge)
+- Hovering or tapping the badge shows: *"Booked by [Booker Name]"*
+
+### AC4 — Booking history shows both names
+- In the booker's booking history, the appointment card shows:
+  - Doctor and clinic name (as usual)
+  - Token number (as usual)
+  - A line: **"Patient: [Beneficiary Name]"** below the doctor name
+  - The status and ETA behave identically to a self-booking
+
+### AC5 — Cancellation and refund follow same rules
+- The **booker** can cancel the appointment (subject to same restrictions — not after doctor arrives)
+- Refund goes back to the **booker's wallet**
+- Beneficiary's phone is notified via SMS if the SMS service is active
+
+### AC6 — Attender can identify on-behalf bookings
+- On the attender dashboard, on-behalf appointments are visually distinct from self-bookings and walk-ins
+- The attender can see the booker's name in the appointment detail view if needed
+
+---
+
+## Out of Scope (this story)
+
+- Beneficiary does not get app notifications (they may get SMS if phone is provided)
+- Beneficiary cannot view or manage the appointment from the app
+- No limit on how many on-behalf bookings a user can make
+- No verification that the beneficiary's phone number is real
+
+---
+
+## Data Model Changes
+
+### `appointments` table — reuse existing fields
+
+| Field | Change | Purpose |
+|---|---|---|
+| `guestName` | Reuse (currently walk-in only) | Store beneficiary name |
+| `guestPhone` | Reuse (currently walk-in only) | Store beneficiary phone |
+| `isWalkIn` | No change | Stays `false` for on-behalf bookings |
+| `patientId` | No change | Still the booker's user ID (for wallet, auth, history) |
+| `isOnBehalf` | **New boolean field** (default `false`) | Distinguishes on-behalf from self and walk-in |
+
+> `guestName` and `guestPhone` are already nullable columns used for walk-ins. On-behalf bookings reuse these same columns — `isOnBehalf = true` is the differentiator.
+
+---
+
+## API Changes
+
+### `POST /api/appointments`
+Add optional fields to the request body:
+```json
+{
+  "doctorId": 34,
+  "clinicId": 3,
+  "scheduleId": 12,
+  "date": "2026-04-08",
+  "isOnBehalf": true,
+  "guestName": "Rajan Kumar",
+  "guestPhone": "9876543210"
+}
+```
+**Validation:**
+- If `isOnBehalf = true`, both `guestName` and `guestPhone` are required
+- `patientId` is always set to `req.user.id` regardless
+
+---
+
+## UI Changes
+
+### Patient Clinic Details page — Booking dialog
+```
+┌─────────────────────────────────────┐
+│  Book Appointment                   │
+│  Dr. Karthik Rajan — Apr 10, 2026  │
+│                                     │
+│  [ ] Booking for someone else       │  ← toggle
+│                                     │
+│  (when toggled on)                  │
+│  Patient Name *                     │
+│  [________________________]         │
+│                                     │
+│  Patient Phone *                    │
+│  [________________________]         │
+│                                     │
+│  Fee: ₹21 from your wallet          │
+│  [    Confirm Booking    ]          │
+└─────────────────────────────────────┘
+```
+
+### Attender Dashboard — Token row
+```
+Token #  Patient              In Time   Status
+  3      Rajan Kumar          -         Scheduled   [Start] [Hold] [No Show]
+         On behalf ⓘ
+         (tooltip: Booked by Ravi Krishnan)
+```
+
+### Patient Booking History — Appointment card
+```
+┌────────────────────────────────────────┐
+│ Dr. Karthik Rajan        [Scheduled]  │
+│ General Medicine                       │
+│ Apr 10, 2026             Token #3     │
+│ Patient: Rajan Kumar                   │  ← new line
+│ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ │
+│ Waiting for your appointment           │
+└────────────────────────────────────────┘
+```
+
+---
+
+## Edge Cases
+
+| Scenario | Behaviour |
+|---|---|
+| Booker tries to book for themselves with toggle on | Allowed — they can enter their own name |
+| Beneficiary name left blank with toggle on | Validation error: "Patient name is required" |
+| Beneficiary phone is invalid format | Validation error: "Enter a valid 10-digit phone number" |
+| Booker cancels an on-behalf appointment before doctor arrives | Full refund to booker's wallet |
+| Booker tries to cancel after doctor arrives | Blocked — same rule as self-bookings |
+| Two on-behalf bookings for same schedule | Allowed — each gets a separate token |
+| Walk-in vs on-behalf conflict on token number | No conflict — on-behalf goes through normal online booking flow |
+
+---
+
+## Implementation Plan
+
+1. **Schema** — Add `isOnBehalf boolean default false` to `appointments` table; migration required
+2. **Server** — Update `POST /api/appointments` to accept and store `isOnBehalf`, `guestName`, `guestPhone`
+3. **Client — Booking dialog** — Add "Book for someone else" toggle + conditional name/phone fields
+4. **Client — Booking history** — Show beneficiary name when `isOnBehalf = true`
+5. **Client — Attender dashboard** — Show "On behalf" badge with booker tooltip
+6. **Test** — Book on behalf, verify token name, cancel and verify refund to booker
+
+---
+
+## Story Points Estimate
+
+| Task | Effort |
+|---|---|
+| Schema migration | XS |
+| API update | S |
+| Booking dialog UI | M |
+| Booking history UI | S |
+| Attender dashboard badge | S |
+| Testing | S |
+| **Total** | **~M (2–3 days)** |

--- a/docs/user-stories/walk-in-token-reservation.md
+++ b/docs/user-stories/walk-in-token-reservation.md
@@ -1,0 +1,53 @@
+# User Story: Walk-in Token Reservation
+
+## Problem Statement
+
+When an attender is creating a token for a walk-in patient (User B), there is a window of time before the booking is completed. During this window, an online patient (User C) can complete their booking and receive the next token number — effectively jumping ahead of the walk-in patient who was physically present first.
+
+**Example scenario:**
+- User A is on token 5 (in_progress)
+- User B arrives at the clinic as a walk-in — attender starts creating token
+- Attender takes 1 minute to complete the booking
+- User C books online during that 1 minute and gets token 6
+- User B ends up with token 7 — even though they arrived before User C booked
+
+---
+
+## User Story
+
+**As an** attender,
+**I want to** instantly reserve the next token number the moment a walk-in patient arrives,
+**So that** online bookings cannot take that token while I'm filling in the patient's details.
+
+---
+
+## Acceptance Criteria
+
+1. Attender dashboard has a **"New Walk-in"** button that **immediately reserves** the next token number upon click
+2. Reserved token is locked for **5 minutes** — online patients cannot take that token during this window
+3. Attender fills in patient details (name/phone) after reservation
+4. On completion → appointment is created with the reserved token number
+5. If attender cancels or the 5-minute window expires → reserved token is released and the next online/walk-in booking gets it
+6. Reserved token is visually shown in the queue as **"Reserving..."** so the doctor/attender can see it in the live queue
+
+---
+
+## Technical Scope
+
+| Area | Change |
+|------|--------|
+| DB | New `tokenReservations` table (`scheduleId`, `tokenNumber`, `reservedAt`, `expiresAt`, `status`) |
+| Backend | `POST /api/schedules/:id/reserve-token` — reserve next token number instantly |
+| Backend | `POST /api/schedules/:id/confirm-walkin` — complete walk-in with reserved token |
+| Backend | Auto-expire reservations after 5 min (checked on next booking attempt) |
+| Frontend | Split attender "New Walk-in" into 2-step flow: Reserve → Fill Details |
+
+---
+
+## Branch
+
+`walk-in-token-reservation`
+
+## Created
+
+2026-04-08

--- a/migrations/0000_familiar_gunslinger.sql
+++ b/migrations/0000_familiar_gunslinger.sql
@@ -1,0 +1,281 @@
+CREATE TABLE "admin_configurations" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"config_key" varchar(100) NOT NULL,
+	"config_value" text NOT NULL,
+	"config_type" varchar(20) DEFAULT 'string' NOT NULL,
+	"description" text,
+	"category" varchar(50) DEFAULT 'general' NOT NULL,
+	"is_editable" boolean DEFAULT true,
+	"created_by" integer,
+	"updated_by" integer,
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP,
+	"updated_at" timestamp DEFAULT CURRENT_TIMESTAMP,
+	CONSTRAINT "admin_configurations_config_key_unique" UNIQUE("config_key")
+);
+--> statement-breakpoint
+CREATE TABLE "appointment_refunds" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"appointment_id" integer NOT NULL,
+	"patient_id" integer NOT NULL,
+	"schedule_id" integer NOT NULL,
+	"doctor_id" integer NOT NULL,
+	"clinic_id" integer NOT NULL,
+	"original_amount" numeric(10, 2) NOT NULL,
+	"refund_amount" numeric(10, 2) NOT NULL,
+	"refund_reason" varchar(100) NOT NULL,
+	"refund_type" varchar(50) NOT NULL,
+	"wallet_transaction_id" integer,
+	"processed_by" integer NOT NULL,
+	"processed_at" timestamp DEFAULT CURRENT_TIMESTAMP,
+	"notes" text,
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP
+);
+--> statement-breakpoint
+CREATE TABLE "appointments" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"patient_id" integer,
+	"doctor_id" integer,
+	"clinic_id" integer,
+	"schedule_id" integer,
+	"date" timestamp NOT NULL,
+	"token_number" integer NOT NULL,
+	"status" varchar(50) DEFAULT 'token_started',
+	"status_notes" text,
+	"guest_name" varchar(255),
+	"guest_phone" varchar(20),
+	"is_walk_in" boolean DEFAULT false,
+	"estimated_start_time" timestamp,
+	"actual_start_time" timestamp,
+	"actual_end_time" timestamp,
+	"consultation_fee" numeric(10, 2) DEFAULT '0.00',
+	"is_paid" boolean DEFAULT false,
+	"payment_method" varchar(50) DEFAULT 'wallet',
+	"wallet_transaction_id" integer,
+	"is_refund_eligible" boolean DEFAULT true,
+	"has_been_refunded" boolean DEFAULT false,
+	"refund_amount" numeric(10, 2) DEFAULT '0.00',
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP
+);
+--> statement-breakpoint
+CREATE TABLE "attender_doctors" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"attender_id" integer NOT NULL,
+	"doctor_id" integer NOT NULL,
+	"clinic_id" integer,
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP
+);
+--> statement-breakpoint
+CREATE TABLE "clinics" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"address" varchar(255),
+	"city" varchar(100),
+	"state" varchar(100),
+	"zip_code" varchar(20),
+	"opening_hours" text,
+	"description" text,
+	"phone" varchar(20),
+	"email" varchar(255),
+	"latitude" numeric(10, 8),
+	"longitude" numeric(11, 8),
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP
+);
+--> statement-breakpoint
+CREATE TABLE "doctor_clinics" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"doctor_id" integer NOT NULL,
+	"clinic_id" integer NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "doctor_daily_presence" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"doctor_id" integer NOT NULL,
+	"clinic_id" integer NOT NULL,
+	"schedule_id" integer,
+	"date" timestamp NOT NULL,
+	"has_arrived" boolean DEFAULT false,
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP,
+	"updated_at" timestamp DEFAULT CURRENT_TIMESTAMP
+);
+--> statement-breakpoint
+CREATE TABLE "doctor_details" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"doctor_id" integer NOT NULL,
+	"consultation_fee" numeric(10, 2) NOT NULL,
+	"consultation_duration" integer NOT NULL,
+	"qualifications" text,
+	"experience" integer,
+	"registration_number" varchar(100),
+	"is_enabled" boolean DEFAULT true,
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP,
+	"updated_at" timestamp DEFAULT CURRENT_TIMESTAMP
+);
+--> statement-breakpoint
+CREATE TABLE "doctor_schedules" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"doctor_id" integer NOT NULL,
+	"clinic_id" integer NOT NULL,
+	"date" date NOT NULL,
+	"start_time" varchar(5) NOT NULL,
+	"end_time" varchar(5) NOT NULL,
+	"max_tokens" integer DEFAULT 20,
+	"is_paused" boolean DEFAULT false,
+	"pause_reason" text,
+	"paused_at" timestamp,
+	"resumed_at" timestamp,
+	"is_active" boolean DEFAULT true,
+	"is_visible" boolean DEFAULT false,
+	"status" varchar(20) DEFAULT 'active',
+	"cancel_reason" text,
+	"cancelled_at" timestamp,
+	"schedule_status" varchar(20) DEFAULT 'active',
+	"booking_status" varchar(20) DEFAULT 'open',
+	"completed_at" timestamp,
+	"booking_closed_at" timestamp,
+	"average_consultation_time" integer DEFAULT 15,
+	"actual_arrival_time" timestamp,
+	"created_by" integer,
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP,
+	"updated_at" timestamp DEFAULT CURRENT_TIMESTAMP
+);
+--> statement-breakpoint
+CREATE TABLE "login_attempts" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" integer,
+	"login_type" varchar(20),
+	"ip_address" varchar(45),
+	"user_agent" text,
+	"success" boolean NOT NULL,
+	"attempted_at" timestamp DEFAULT CURRENT_TIMESTAMP,
+	"failure_reason" varchar(255)
+);
+--> statement-breakpoint
+CREATE TABLE "notifications" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" integer NOT NULL,
+	"appointment_id" integer,
+	"title" varchar(100) NOT NULL,
+	"message" text NOT NULL,
+	"type" varchar(50) NOT NULL,
+	"is_read" boolean DEFAULT false,
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP
+);
+--> statement-breakpoint
+CREATE TABLE "otp_verifications" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"phone" varchar(20) NOT NULL,
+	"otp_code" varchar(6) NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"verified" boolean DEFAULT false,
+	"verification_attempts" integer DEFAULT 0,
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP
+);
+--> statement-breakpoint
+CREATE TABLE "patient_favorites" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"patient_id" integer NOT NULL,
+	"doctor_id" integer NOT NULL,
+	"schedule_id" integer NOT NULL,
+	"clinic_id" integer NOT NULL,
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP
+);
+--> statement-breakpoint
+CREATE TABLE "patient_wallets" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"patient_id" integer NOT NULL,
+	"balance" numeric(10, 2) DEFAULT '0.00' NOT NULL,
+	"total_earned" numeric(10, 2) DEFAULT '0.00' NOT NULL,
+	"total_spent" numeric(10, 2) DEFAULT '0.00' NOT NULL,
+	"is_active" boolean DEFAULT true,
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP,
+	"updated_at" timestamp DEFAULT CURRENT_TIMESTAMP
+);
+--> statement-breakpoint
+CREATE TABLE "users" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"username" varchar(255) NOT NULL,
+	"password" varchar(255) NOT NULL,
+	"role" varchar(50) NOT NULL,
+	"phone" varchar(20) NOT NULL,
+	"email" varchar(255),
+	"specialty" varchar(255),
+	"bio" text,
+	"image_url" text,
+	"address" text,
+	"city" text,
+	"state" text,
+	"zip_code" text,
+	"latitude" varchar(50),
+	"longitude" varchar(50),
+	"clinic_id" integer,
+	"last_otp_sent_at" timestamp,
+	"phone_verified" boolean DEFAULT false,
+	"must_change_password" boolean DEFAULT false,
+	"mpin" varchar(255),
+	"mpin_attempts" integer DEFAULT 0,
+	"mpin_locked_until" timestamp,
+	"last_mpin_change" timestamp,
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP,
+	CONSTRAINT "users_username_unique" UNIQUE("username"),
+	CONSTRAINT "users_email_unique" UNIQUE("email")
+);
+--> statement-breakpoint
+CREATE TABLE "wallet_transactions" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"wallet_id" integer NOT NULL,
+	"patient_id" integer NOT NULL,
+	"appointment_id" integer,
+	"schedule_id" integer,
+	"transaction_type" varchar(50) NOT NULL,
+	"amount" numeric(10, 2) NOT NULL,
+	"previous_balance" numeric(10, 2) NOT NULL,
+	"new_balance" numeric(10, 2) NOT NULL,
+	"description" text NOT NULL,
+	"reference_id" varchar(100),
+	"processed_by" integer,
+	"status" varchar(20) DEFAULT 'completed',
+	"metadata" text,
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP
+);
+--> statement-breakpoint
+ALTER TABLE "admin_configurations" ADD CONSTRAINT "admin_configurations_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "admin_configurations" ADD CONSTRAINT "admin_configurations_updated_by_users_id_fk" FOREIGN KEY ("updated_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "appointment_refunds" ADD CONSTRAINT "appointment_refunds_appointment_id_appointments_id_fk" FOREIGN KEY ("appointment_id") REFERENCES "public"."appointments"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "appointment_refunds" ADD CONSTRAINT "appointment_refunds_patient_id_users_id_fk" FOREIGN KEY ("patient_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "appointment_refunds" ADD CONSTRAINT "appointment_refunds_schedule_id_doctor_schedules_id_fk" FOREIGN KEY ("schedule_id") REFERENCES "public"."doctor_schedules"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "appointment_refunds" ADD CONSTRAINT "appointment_refunds_doctor_id_users_id_fk" FOREIGN KEY ("doctor_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "appointment_refunds" ADD CONSTRAINT "appointment_refunds_clinic_id_clinics_id_fk" FOREIGN KEY ("clinic_id") REFERENCES "public"."clinics"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "appointment_refunds" ADD CONSTRAINT "appointment_refunds_wallet_transaction_id_wallet_transactions_id_fk" FOREIGN KEY ("wallet_transaction_id") REFERENCES "public"."wallet_transactions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "appointment_refunds" ADD CONSTRAINT "appointment_refunds_processed_by_users_id_fk" FOREIGN KEY ("processed_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "appointments" ADD CONSTRAINT "appointments_patient_id_users_id_fk" FOREIGN KEY ("patient_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "appointments" ADD CONSTRAINT "appointments_doctor_id_users_id_fk" FOREIGN KEY ("doctor_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "appointments" ADD CONSTRAINT "appointments_clinic_id_clinics_id_fk" FOREIGN KEY ("clinic_id") REFERENCES "public"."clinics"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "appointments" ADD CONSTRAINT "appointments_schedule_id_doctor_schedules_id_fk" FOREIGN KEY ("schedule_id") REFERENCES "public"."doctor_schedules"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "appointments" ADD CONSTRAINT "appointments_wallet_transaction_id_wallet_transactions_id_fk" FOREIGN KEY ("wallet_transaction_id") REFERENCES "public"."wallet_transactions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "attender_doctors" ADD CONSTRAINT "attender_doctors_attender_id_users_id_fk" FOREIGN KEY ("attender_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "attender_doctors" ADD CONSTRAINT "attender_doctors_doctor_id_users_id_fk" FOREIGN KEY ("doctor_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "attender_doctors" ADD CONSTRAINT "attender_doctors_clinic_id_clinics_id_fk" FOREIGN KEY ("clinic_id") REFERENCES "public"."clinics"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "doctor_clinics" ADD CONSTRAINT "doctor_clinics_doctor_id_users_id_fk" FOREIGN KEY ("doctor_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "doctor_clinics" ADD CONSTRAINT "doctor_clinics_clinic_id_clinics_id_fk" FOREIGN KEY ("clinic_id") REFERENCES "public"."clinics"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "doctor_daily_presence" ADD CONSTRAINT "doctor_daily_presence_doctor_id_users_id_fk" FOREIGN KEY ("doctor_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "doctor_daily_presence" ADD CONSTRAINT "doctor_daily_presence_clinic_id_clinics_id_fk" FOREIGN KEY ("clinic_id") REFERENCES "public"."clinics"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "doctor_daily_presence" ADD CONSTRAINT "doctor_daily_presence_schedule_id_doctor_schedules_id_fk" FOREIGN KEY ("schedule_id") REFERENCES "public"."doctor_schedules"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "doctor_details" ADD CONSTRAINT "doctor_details_doctor_id_users_id_fk" FOREIGN KEY ("doctor_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "doctor_schedules" ADD CONSTRAINT "doctor_schedules_doctor_id_users_id_fk" FOREIGN KEY ("doctor_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "doctor_schedules" ADD CONSTRAINT "doctor_schedules_clinic_id_clinics_id_fk" FOREIGN KEY ("clinic_id") REFERENCES "public"."clinics"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "doctor_schedules" ADD CONSTRAINT "doctor_schedules_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "login_attempts" ADD CONSTRAINT "login_attempts_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_appointment_id_appointments_id_fk" FOREIGN KEY ("appointment_id") REFERENCES "public"."appointments"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "patient_favorites" ADD CONSTRAINT "patient_favorites_patient_id_users_id_fk" FOREIGN KEY ("patient_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "patient_favorites" ADD CONSTRAINT "patient_favorites_doctor_id_users_id_fk" FOREIGN KEY ("doctor_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "patient_favorites" ADD CONSTRAINT "patient_favorites_schedule_id_doctor_schedules_id_fk" FOREIGN KEY ("schedule_id") REFERENCES "public"."doctor_schedules"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "patient_favorites" ADD CONSTRAINT "patient_favorites_clinic_id_clinics_id_fk" FOREIGN KEY ("clinic_id") REFERENCES "public"."clinics"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "patient_wallets" ADD CONSTRAINT "patient_wallets_patient_id_users_id_fk" FOREIGN KEY ("patient_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "users" ADD CONSTRAINT "users_clinic_id_clinics_id_fk" FOREIGN KEY ("clinic_id") REFERENCES "public"."clinics"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "wallet_transactions" ADD CONSTRAINT "wallet_transactions_wallet_id_patient_wallets_id_fk" FOREIGN KEY ("wallet_id") REFERENCES "public"."patient_wallets"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "wallet_transactions" ADD CONSTRAINT "wallet_transactions_patient_id_users_id_fk" FOREIGN KEY ("patient_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "wallet_transactions" ADD CONSTRAINT "wallet_transactions_appointment_id_appointments_id_fk" FOREIGN KEY ("appointment_id") REFERENCES "public"."appointments"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "wallet_transactions" ADD CONSTRAINT "wallet_transactions_schedule_id_doctor_schedules_id_fk" FOREIGN KEY ("schedule_id") REFERENCES "public"."doctor_schedules"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "wallet_transactions" ADD CONSTRAINT "wallet_transactions_processed_by_users_id_fk" FOREIGN KEY ("processed_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;

--- a/migrations/meta/0000_snapshot.json
+++ b/migrations/meta/0000_snapshot.json
@@ -1,0 +1,1977 @@
+{
+  "id": "37563b57-59f3-429d-88fb-c8ede2a89dd2",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admin_configurations": {
+      "name": "admin_configurations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_key": {
+          "name": "config_key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_value": {
+          "name": "config_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_type": {
+          "name": "config_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'string'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "is_editable": {
+          "name": "is_editable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_configurations_created_by_users_id_fk": {
+          "name": "admin_configurations_created_by_users_id_fk",
+          "tableFrom": "admin_configurations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "admin_configurations_updated_by_users_id_fk": {
+          "name": "admin_configurations_updated_by_users_id_fk",
+          "tableFrom": "admin_configurations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_configurations_config_key_unique": {
+          "name": "admin_configurations_config_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "config_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointment_refunds": {
+      "name": "appointment_refunds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doctor_id": {
+          "name": "doctor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clinic_id": {
+          "name": "clinic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_amount": {
+          "name": "original_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refund_amount": {
+          "name": "refund_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refund_reason": {
+          "name": "refund_reason",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refund_type": {
+          "name": "refund_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_transaction_id": {
+          "name": "wallet_transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_by": {
+          "name": "processed_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "appointment_refunds_appointment_id_appointments_id_fk": {
+          "name": "appointment_refunds_appointment_id_appointments_id_fk",
+          "tableFrom": "appointment_refunds",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_refunds_patient_id_users_id_fk": {
+          "name": "appointment_refunds_patient_id_users_id_fk",
+          "tableFrom": "appointment_refunds",
+          "tableTo": "users",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_refunds_schedule_id_doctor_schedules_id_fk": {
+          "name": "appointment_refunds_schedule_id_doctor_schedules_id_fk",
+          "tableFrom": "appointment_refunds",
+          "tableTo": "doctor_schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_refunds_doctor_id_users_id_fk": {
+          "name": "appointment_refunds_doctor_id_users_id_fk",
+          "tableFrom": "appointment_refunds",
+          "tableTo": "users",
+          "columnsFrom": [
+            "doctor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_refunds_clinic_id_clinics_id_fk": {
+          "name": "appointment_refunds_clinic_id_clinics_id_fk",
+          "tableFrom": "appointment_refunds",
+          "tableTo": "clinics",
+          "columnsFrom": [
+            "clinic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_refunds_wallet_transaction_id_wallet_transactions_id_fk": {
+          "name": "appointment_refunds_wallet_transaction_id_wallet_transactions_id_fk",
+          "tableFrom": "appointment_refunds",
+          "tableTo": "wallet_transactions",
+          "columnsFrom": [
+            "wallet_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_refunds_processed_by_users_id_fk": {
+          "name": "appointment_refunds_processed_by_users_id_fk",
+          "tableFrom": "appointment_refunds",
+          "tableTo": "users",
+          "columnsFrom": [
+            "processed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointments": {
+      "name": "appointments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doctor_id": {
+          "name": "doctor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_id": {
+          "name": "clinic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_number": {
+          "name": "token_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'token_started'"
+        },
+        "status_notes": {
+          "name": "status_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_name": {
+          "name": "guest_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_phone": {
+          "name": "guest_phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_walk_in": {
+          "name": "is_walk_in",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "estimated_start_time": {
+          "name": "estimated_start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actual_start_time": {
+          "name": "actual_start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actual_end_time": {
+          "name": "actual_end_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consultation_fee": {
+          "name": "consultation_fee",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.00'"
+        },
+        "is_paid": {
+          "name": "is_paid",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'wallet'"
+        },
+        "wallet_transaction_id": {
+          "name": "wallet_transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_refund_eligible": {
+          "name": "is_refund_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "has_been_refunded": {
+          "name": "has_been_refunded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "refund_amount": {
+          "name": "refund_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.00'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "appointments_patient_id_users_id_fk": {
+          "name": "appointments_patient_id_users_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_doctor_id_users_id_fk": {
+          "name": "appointments_doctor_id_users_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "doctor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_clinic_id_clinics_id_fk": {
+          "name": "appointments_clinic_id_clinics_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "clinics",
+          "columnsFrom": [
+            "clinic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_schedule_id_doctor_schedules_id_fk": {
+          "name": "appointments_schedule_id_doctor_schedules_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "doctor_schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_wallet_transaction_id_wallet_transactions_id_fk": {
+          "name": "appointments_wallet_transaction_id_wallet_transactions_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "wallet_transactions",
+          "columnsFrom": [
+            "wallet_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attender_doctors": {
+      "name": "attender_doctors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "attender_id": {
+          "name": "attender_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doctor_id": {
+          "name": "doctor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clinic_id": {
+          "name": "clinic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attender_doctors_attender_id_users_id_fk": {
+          "name": "attender_doctors_attender_id_users_id_fk",
+          "tableFrom": "attender_doctors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "attender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attender_doctors_doctor_id_users_id_fk": {
+          "name": "attender_doctors_doctor_id_users_id_fk",
+          "tableFrom": "attender_doctors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "doctor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attender_doctors_clinic_id_clinics_id_fk": {
+          "name": "attender_doctors_clinic_id_clinics_id_fk",
+          "tableFrom": "attender_doctors",
+          "tableTo": "clinics",
+          "columnsFrom": [
+            "clinic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clinics": {
+      "name": "clinics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip_code": {
+          "name": "zip_code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_hours": {
+          "name": "opening_hours",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "numeric(10, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "numeric(11, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.doctor_clinics": {
+      "name": "doctor_clinics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "doctor_id": {
+          "name": "doctor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clinic_id": {
+          "name": "clinic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "doctor_clinics_doctor_id_users_id_fk": {
+          "name": "doctor_clinics_doctor_id_users_id_fk",
+          "tableFrom": "doctor_clinics",
+          "tableTo": "users",
+          "columnsFrom": [
+            "doctor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "doctor_clinics_clinic_id_clinics_id_fk": {
+          "name": "doctor_clinics_clinic_id_clinics_id_fk",
+          "tableFrom": "doctor_clinics",
+          "tableTo": "clinics",
+          "columnsFrom": [
+            "clinic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.doctor_daily_presence": {
+      "name": "doctor_daily_presence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "doctor_id": {
+          "name": "doctor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clinic_id": {
+          "name": "clinic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_arrived": {
+          "name": "has_arrived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "doctor_daily_presence_doctor_id_users_id_fk": {
+          "name": "doctor_daily_presence_doctor_id_users_id_fk",
+          "tableFrom": "doctor_daily_presence",
+          "tableTo": "users",
+          "columnsFrom": [
+            "doctor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "doctor_daily_presence_clinic_id_clinics_id_fk": {
+          "name": "doctor_daily_presence_clinic_id_clinics_id_fk",
+          "tableFrom": "doctor_daily_presence",
+          "tableTo": "clinics",
+          "columnsFrom": [
+            "clinic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "doctor_daily_presence_schedule_id_doctor_schedules_id_fk": {
+          "name": "doctor_daily_presence_schedule_id_doctor_schedules_id_fk",
+          "tableFrom": "doctor_daily_presence",
+          "tableTo": "doctor_schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.doctor_details": {
+      "name": "doctor_details",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "doctor_id": {
+          "name": "doctor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consultation_fee": {
+          "name": "consultation_fee",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consultation_duration": {
+          "name": "consultation_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qualifications": {
+          "name": "qualifications",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experience": {
+          "name": "experience",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_number": {
+          "name": "registration_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "doctor_details_doctor_id_users_id_fk": {
+          "name": "doctor_details_doctor_id_users_id_fk",
+          "tableFrom": "doctor_details",
+          "tableTo": "users",
+          "columnsFrom": [
+            "doctor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.doctor_schedules": {
+      "name": "doctor_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "doctor_id": {
+          "name": "doctor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clinic_id": {
+          "name": "clinic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 20
+        },
+        "is_paused": {
+          "name": "is_paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "pause_reason": {
+          "name": "pause_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resumed_at": {
+          "name": "resumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "is_visible": {
+          "name": "is_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "cancel_reason": {
+          "name": "cancel_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_status": {
+          "name": "schedule_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "booking_status": {
+          "name": "booking_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'open'"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "booking_closed_at": {
+          "name": "booking_closed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "average_consultation_time": {
+          "name": "average_consultation_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 15
+        },
+        "actual_arrival_time": {
+          "name": "actual_arrival_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "doctor_schedules_doctor_id_users_id_fk": {
+          "name": "doctor_schedules_doctor_id_users_id_fk",
+          "tableFrom": "doctor_schedules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "doctor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "doctor_schedules_clinic_id_clinics_id_fk": {
+          "name": "doctor_schedules_clinic_id_clinics_id_fk",
+          "tableFrom": "doctor_schedules",
+          "tableTo": "clinics",
+          "columnsFrom": [
+            "clinic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "doctor_schedules_created_by_users_id_fk": {
+          "name": "doctor_schedules_created_by_users_id_fk",
+          "tableFrom": "doctor_schedules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.login_attempts": {
+      "name": "login_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "login_type": {
+          "name": "login_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "login_attempts_user_id_users_id_fk": {
+          "name": "login_attempts_user_id_users_id_fk",
+          "tableFrom": "login_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_appointment_id_appointments_id_fk": {
+          "name": "notifications_appointment_id_appointments_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.otp_verifications": {
+      "name": "otp_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "otp_code": {
+          "name": "otp_code",
+          "type": "varchar(6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "verification_attempts": {
+          "name": "verification_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patient_favorites": {
+      "name": "patient_favorites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doctor_id": {
+          "name": "doctor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clinic_id": {
+          "name": "clinic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "patient_favorites_patient_id_users_id_fk": {
+          "name": "patient_favorites_patient_id_users_id_fk",
+          "tableFrom": "patient_favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_favorites_doctor_id_users_id_fk": {
+          "name": "patient_favorites_doctor_id_users_id_fk",
+          "tableFrom": "patient_favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "doctor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_favorites_schedule_id_doctor_schedules_id_fk": {
+          "name": "patient_favorites_schedule_id_doctor_schedules_id_fk",
+          "tableFrom": "patient_favorites",
+          "tableTo": "doctor_schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_favorites_clinic_id_clinics_id_fk": {
+          "name": "patient_favorites_clinic_id_clinics_id_fk",
+          "tableFrom": "patient_favorites",
+          "tableTo": "clinics",
+          "columnsFrom": [
+            "clinic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patient_wallets": {
+      "name": "patient_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "total_earned": {
+          "name": "total_earned",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "total_spent": {
+          "name": "total_spent",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "patient_wallets_patient_id_users_id_fk": {
+          "name": "patient_wallets_patient_id_users_id_fk",
+          "tableFrom": "patient_wallets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specialty": {
+          "name": "specialty",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip_code": {
+          "name": "zip_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_id": {
+          "name": "clinic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_otp_sent_at": {
+          "name": "last_otp_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_verified": {
+          "name": "phone_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "mpin": {
+          "name": "mpin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mpin_attempts": {
+          "name": "mpin_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "mpin_locked_until": {
+          "name": "mpin_locked_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_mpin_change": {
+          "name": "last_mpin_change",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_clinic_id_clinics_id_fk": {
+          "name": "users_clinic_id_clinics_id_fk",
+          "tableFrom": "users",
+          "tableTo": "clinics",
+          "columnsFrom": [
+            "clinic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_transactions": {
+      "name": "wallet_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_type": {
+          "name": "transaction_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_balance": {
+          "name": "previous_balance",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_balance": {
+          "name": "new_balance",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_by": {
+          "name": "processed_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'completed'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wallet_transactions_wallet_id_patient_wallets_id_fk": {
+          "name": "wallet_transactions_wallet_id_patient_wallets_id_fk",
+          "tableFrom": "wallet_transactions",
+          "tableTo": "patient_wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wallet_transactions_patient_id_users_id_fk": {
+          "name": "wallet_transactions_patient_id_users_id_fk",
+          "tableFrom": "wallet_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wallet_transactions_appointment_id_appointments_id_fk": {
+          "name": "wallet_transactions_appointment_id_appointments_id_fk",
+          "tableFrom": "wallet_transactions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wallet_transactions_schedule_id_doctor_schedules_id_fk": {
+          "name": "wallet_transactions_schedule_id_doctor_schedules_id_fk",
+          "tableFrom": "wallet_transactions",
+          "tableTo": "doctor_schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wallet_transactions_processed_by_users_id_fk": {
+          "name": "wallet_transactions_processed_by_users_id_fk",
+          "tableFrom": "wallet_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "processed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1775457512875,
+      "tag": "0000_familiar_gunslinger",
+      "breakpoints": true
+    }
+  ]
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -609,6 +609,16 @@ export async function registerRoutes(app: Express): Promise<Server> {
         });
       }
 
+      // Validate on-behalf fields when booking for someone else
+      if (req.body.isOnBehalf) {
+        if (!req.body.guestName?.trim()) {
+          return res.status(400).json({ message: 'Patient name is required when booking for someone else' });
+        }
+        if (!/^\d{10}$/.test(req.body.guestPhone?.trim() || '')) {
+          return res.status(400).json({ message: 'A valid 10-digit phone number is required when booking for someone else' });
+        }
+      }
+
       const appointmentData = {
         ...req.body,
         patientId: req.user.id,
@@ -619,7 +629,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
         consultationFee: totalAmount, // Store total amount as consultation fee
         isPaid: true,
         paymentMethod: 'wallet',
-        isRefundEligible: true
+        isRefundEligible: true,
+        isOnBehalf: req.body.isOnBehalf || false,
+        guestName: req.body.isOnBehalf ? req.body.guestName?.trim() : null,
+        guestPhone: req.body.isOnBehalf ? req.body.guestPhone?.trim() : null,
       };
 
       // Create appointment and process wallet payment

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -2391,12 +2391,12 @@ export class DatabaseStorage implements IStorage {
               )
             );
 
-          // Get patient data for these appointments
-          const patientIds = Array.from(new Set(appointmentsForDoctor.map(apt => apt.patientId)));
-          const patients = await db
+          // Get patient data for these appointments (filter out nulls from walk-ins)
+          const patientIds = Array.from(new Set(appointmentsForDoctor.map(apt => apt.patientId).filter((id): id is number => id != null)));
+          const patients = patientIds.length > 0 ? await db
             .select()
             .from(users)
-            .where(inArray(users.id, patientIds));
+            .where(inArray(users.id, patientIds)) : [];
 
           const patientsMap = new Map(patients.map(p => [p.id, p]));
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -119,10 +119,11 @@ export const appointments = pgTable("appointments", {
   tokenNumber: integer("token_number").notNull(),
   status: varchar("status", { length: 50 }).default("token_started"),
   statusNotes: text("status_notes"), // For recording reasons for status changes
-  // Guest patient fields for walk-in appointments
+  // Guest patient fields for walk-in and on-behalf appointments
   guestName: varchar("guest_name", { length: 255 }),
   guestPhone: varchar("guest_phone", { length: 20 }),
   isWalkIn: boolean("is_walk_in").default(false),
+  isOnBehalf: boolean("is_on_behalf").default(false),
   // ETA tracking fields
   estimatedStartTime: timestamp("estimated_start_time"),
   actualStartTime: timestamp("actual_start_time"),


### PR DESCRIPTION
## Summary
- Patients can now book appointments on behalf of someone else (family member, friend, etc.)
- Added `isOnBehalf`, `guestName`, `guestPhone` fields to the appointments schema
- Booking dialog now shows a "Booking for someone else?" checkbox before confirming — if checked, name and 10-digit phone are required
- Attender dashboard shows **On behalf** badge with **by [booker name]** for these appointments
- Patient booking history shows the guest patient name under on-behalf bookings
- Fixed null `patientId` crash in attender appointments query caused by walk-in appointments

## Test plan
- [ ] Book an appointment normally — confirm dialog appears, booking works as before
- [ ] Book with "Booking for someone else?" checked — confirm name + phone are required
- [ ] Check attender dashboard — on-behalf appointments show guest name, "On behalf" badge, and "by [booker]"
- [ ] Check booking history — on-behalf appointments show "Patient: [guest name]"
- [ ] Try submitting on-behalf with invalid phone (non-10-digit) — confirm validation error
- [ ] Confirm walk-in appointments still display correctly in attender dashboard (null patientId fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)