### PR TITLE
fix: pre-populate admin fields on clinic edit

### DIFF
--- a/client/src/pages/super-admin-dashboard.tsx
+++ b/client/src/pages/super-admin-dashboard.tsx
@@ -329,7 +329,7 @@ export default function SuperAdminDashboard() {
 
   // Form for creating clinics with admin
   const form = useForm<ClinicData>({
-    resolver: zodResolver(clinicSchema),
+    resolver: zodResolver(editClinicSchema),
     defaultValues: {
       name: "",
       address: "",
@@ -455,6 +455,29 @@ export default function SuperAdminDashboard() {
   };
 
   const onCreateSubmit = (data: ClinicData) => {
+    // Manually validate required admin fields for clinic creation
+    let hasError = false;
+    if (!data.adminUsername?.trim()) {
+      form.setError('adminUsername', { message: 'Admin username is required' });
+      hasError = true;
+    }
+    if (!data.adminPassword || data.adminPassword.length < 6) {
+      form.setError('adminPassword', { message: 'Admin password must be at least 6 characters' });
+      hasError = true;
+    }
+    if (!data.adminName?.trim()) {
+      form.setError('adminName', { message: 'Admin full name is required' });
+      hasError = true;
+    }
+    if (!data.adminPhone?.trim()) {
+      form.setError('adminPhone', { message: 'Admin phone number is required' });
+      hasError = true;
+    }
+    if (!data.adminEmail?.trim()) {
+      form.setError('adminEmail', { message: 'Admin email is required' });
+      hasError = true;
+    }
+    if (hasError) return;
     createClinicMutation.mutate(data);
   };
 
@@ -472,7 +495,7 @@ export default function SuperAdminDashboard() {
   };
 
   // Handler for Edit button
-  const handleEdit = (clinic: any) => {
+  const handleEdit = async (clinic: any) => {
     setSelectedClinic(clinic);
     // Populate form with clinic data for editing
     form.setValue('name', clinic.name);
@@ -485,12 +508,22 @@ export default function SuperAdminDashboard() {
     form.setValue('openingHours', clinic.openingHours);
     form.setValue('description', clinic.description || '');
     form.setValue('imageUrl', clinic.imageUrl || '');
-    // Reset admin fields for security
-    form.setValue('adminUsername', '');
-    form.setValue('adminPassword', '');
-    form.setValue('adminName', '');
-    form.setValue('adminPhone', '');
-    form.setValue('adminEmail', '');
+    // Fetch clinic with admin data to pre-populate admin fields (password intentionally left blank)
+    try {
+      const res = await apiRequest('GET', `/api/clinics/${clinic.id}`);
+      const data = await res.json();
+      const admin = data.admin;
+      form.setValue('adminUsername', admin?.username || '');
+      form.setValue('adminName', admin?.name || '');
+      form.setValue('adminPhone', admin?.phone || '');
+      form.setValue('adminEmail', admin?.email || '');
+    } catch {
+      form.setValue('adminUsername', '');
+      form.setValue('adminName', '');
+      form.setValue('adminPhone', '');
+      form.setValue('adminEmail', '');
+    }
+    form.setValue('adminPassword', ''); // Always blank — only fill to change password
     setShowEditForm(true);
   };
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1106,11 +1106,17 @@ export async function registerRoutes(app: Express): Promise<Server> {
     try {
       const clinicId = parseInt(req.params.id);
       const clinic = await storage.getClinic(clinicId);
-      
+
       if (!clinic) {
         return res.status(404).json({ message: 'Clinic not found' });
       }
-      
+
+      // Include admin user data for super_admin (excluding password)
+      if (req.user?.role === 'super_admin') {
+        const admin = await storage.getClinicAdminByClinicId(clinicId);
+        return res.json({ ...clinic, admin: admin || null });
+      }
+
       res.json(clinic);
     } catch (error) {
       console.error('Error fetching clinic:', error);
@@ -1135,13 +1141,37 @@ export async function registerRoutes(app: Express): Promise<Server> {
     try {
       const clinicId = parseInt(req.params.id);
       const clinic = await storage.getClinic(clinicId);
-      
+
       if (!clinic) {
         return res.status(404).json({ message: 'Clinic not found' });
       }
-      
+
       const updatedClinic = await storage.updateClinic(clinicId, req.body);
-      res.json(updatedClinic);
+
+      // Update admin user fields if provided
+      const { adminName, adminPhone, adminEmail, adminUsername, adminPassword } = req.body;
+      if (adminName || adminPhone || adminEmail || adminUsername || adminPassword) {
+        const admin = await storage.getClinicAdminByClinicId(clinicId);
+        if (admin) {
+          const adminUpdates: Record<string, any> = {};
+          if (adminName) adminUpdates.name = adminName;
+          if (adminPhone) adminUpdates.phone = adminPhone;
+          if (adminEmail) adminUpdates.email = adminEmail;
+          if (adminUsername) adminUpdates.username = adminUsername;
+          if (adminPassword) {
+            const { scrypt, randomBytes } = await import('crypto');
+            const { promisify } = await import('util');
+            const scryptAsync = promisify(scrypt);
+            const salt = randomBytes(16).toString('hex');
+            const buf = (await scryptAsync(adminPassword, salt, 64)) as Buffer;
+            adminUpdates.password = `${buf.toString('hex')}.${salt}`;
+          }
+          await storage.updateUser(admin.id, adminUpdates);
+        }
+      }
+
+      const updatedAdmin = await storage.getClinicAdminByClinicId(clinicId);
+      res.json({ ...updatedClinic, admin: updatedAdmin || null });
     } catch (error) {
       console.error('Error updating clinic:', error);
       res.status(400).json({ message: error instanceof Error ? error.message : 'Invalid clinic data' });

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -124,6 +124,7 @@ export interface IStorage {
   getDoctorsNearLocation(lat: number, lng: number, radiusInMiles?: number): Promise<User[]>;
   getClinicsNearLocation(lat: number, lng: number, radiusInKm?: number): Promise<(Clinic & { distance: number })[]>;
   getClinicAdmins(): Promise<(User & { clinic?: Clinic })[]>;
+  getClinicAdminByClinicId(clinicId: number): Promise<Omit<User, 'password'> | undefined>;
   getClinics(): Promise<Clinic[]>;
   getClinic(id: number): Promise<Clinic | undefined>;
   createClinic(clinic: typeof clinics.$inferInsert): Promise<Clinic>;
@@ -538,6 +539,33 @@ export class DatabaseStorage implements IStorage {
         clinic: clinic || undefined,
       };
     });
+  }
+
+  async getClinicAdminByClinicId(clinicId: number): Promise<Omit<User, 'password'> | undefined> {
+    const [result] = await db
+      .select({
+        id: users.id,
+        username: users.username,
+        name: users.name,
+        role: users.role,
+        phone: users.phone,
+        email: users.email,
+        specialty: users.specialty,
+        bio: users.bio,
+        imageUrl: users.imageUrl,
+        address: users.address,
+        city: users.city,
+        state: users.state,
+        zipCode: users.zipCode,
+        latitude: users.latitude,
+        longitude: users.longitude,
+        clinicId: users.clinicId,
+        createdAt: users.createdAt,
+      })
+      .from(users)
+      .where(and(eq(users.role, 'clinic_admin'), eq(users.clinicId, clinicId)))
+      .limit(1);
+    return result;
   }
 
   async getDoctorWithClinic(id: number): Promise<(User & { clinic?: Clinic }) | undefined> {


### PR DESCRIPTION
## Summary
- Added `getClinicAdminByClinicId()` to fetch clinic admin data without password
- Updated `GET /api/clinics/:id` to return admin info for super_admin role
- Updated `PUT /api/clinics/:id` to update admin fields when provided
- Fixed edit form resolver to use `editClinicSchema` (optional admin fields) so saving works without re-entering password
- `handleEdit()` now fetches and pre-populates admin fields (username, name, phone, email) from the API

## Test plan
- [ ] Open Super Admin dashboard → Edit an existing clinic
- [ ] Verify admin fields (username, name, phone, email) are pre-populated
- [ ] Save without changing anything — should succeed
- [ ] Change admin name/phone and save — should update correctly
- [ ] Change password and save — should re-hash and update

🤖 Generated with [Claude Code](https://claude.com/claude-code)