### PR TITLE
feat: booking settings, ETA fix, lat/lng for clinics

### DIFF
--- a/client/src/hooks/use-app-config.ts
+++ b/client/src/hooks/use-app-config.ts
@@ -39,6 +39,66 @@ export function useAppConfig() {
   };
 }
 
+export function useBookingConfig() {
+  const { data, isLoading } = useQuery({
+    queryKey: ['app-config-booking'],
+    queryFn: async () => {
+      const response = await fetch('/api/configurations/public?category=booking');
+      if (!response.ok) throw new Error('Failed to fetch booking configurations');
+      const result = await response.json();
+      return result.configurations as Record<string, any>;
+    },
+    staleTime: 60 * 1000,
+  });
+
+  return {
+    reservationTimeoutSeconds: (data?.token_reservation_timeout_seconds as number) ?? 300,
+    isLoading,
+  };
+}
+
+export function useAdminBookingConfig() {
+  const queryClient = useQueryClient();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['admin-config-booking'],
+    queryFn: async () => {
+      const response = await fetch('/api/admin/configurations?category=booking');
+      if (!response.ok) throw new Error('Failed to fetch booking configurations');
+      return response.json();
+    },
+    staleTime: 60 * 1000,
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: async (configurations: Record<string, any>) => {
+      const response = await fetch('/api/admin/configurations', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ configurations }),
+      });
+      if (!response.ok) {
+        const err = await response.json();
+        throw new Error(err.message || 'Failed to update configurations');
+      }
+      return response.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin-config-booking'] });
+      queryClient.invalidateQueries({ queryKey: ['app-config-booking'] });
+    },
+  });
+
+  return {
+    configurations: data?.configurations || [],
+    isLoading,
+    error,
+    updateConfigurations: updateMutation.mutateAsync,
+    isUpdating: updateMutation.isPending,
+    updateError: updateMutation.error,
+  };
+}
+
 export function useAdminConfig() {
   const queryClient = useQueryClient();
 

--- a/client/src/pages/attender-dashboard.tsx
+++ b/client/src/pages/attender-dashboard.tsx
@@ -28,6 +28,7 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { NavigationButtons } from "@/components/navigation-buttons";
+import { useBookingConfig } from "@/hooks/use-app-config";
 import React, { useEffect } from "react";
 
 // Updated type definition without presence info in schedules
@@ -59,6 +60,7 @@ type DoctorWithAppointments = {
 export default function AttenderDashboard() {
   const { user } = useAuth();
   const { toast } = useToast();
+  const { reservationTimeoutSeconds } = useBookingConfig();
   const [isPaused, setIsPaused] = useState(false);
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
   const [selectedDoctorId, setSelectedDoctorId] = useState<string>("");
@@ -84,7 +86,7 @@ export default function AttenderDashboard() {
     scheduleId: number;
   } | null>(null);
   const [walkInStep, setWalkInStep] = useState<'idle' | 'reserving' | 'filling'>('idle');
-  const [reservationSecondsLeft, setReservationSecondsLeft] = useState(300);
+  const [reservationSecondsLeft, setReservationSecondsLeft] = useState(0);
 
   // Main query for fetching doctor data with schedules and appointments  
   const { data: managedDoctors, isLoading, error } = useQuery<DoctorWithAppointments[]>({
@@ -265,7 +267,7 @@ export default function AttenderDashboard() {
     setWalkInReservation(null);
     setWalkInCurrentDoctor(null);
     setWalkInFormValues({ doctorId: 0, clinicId: 0, scheduleId: 0, guestName: '', guestPhone: '' });
-    setReservationSecondsLeft(300);
+    setReservationSecondsLeft(reservationTimeoutSeconds);
   };
 
   // Auto-select the first doctor when data loads
@@ -422,7 +424,7 @@ export default function AttenderDashboard() {
     onSuccess: (data) => {
       setWalkInReservation(data);
       setWalkInStep('filling');
-      setReservationSecondsLeft(300);
+      setReservationSecondsLeft(reservationTimeoutSeconds);
     },
     onError: () => {
       toast({ title: "Failed to reserve token", variant: "destructive" });

--- a/client/src/pages/super-admin-dashboard.tsx
+++ b/client/src/pages/super-admin-dashboard.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { DashboardHeader } from "@/components/dashboard-header";
 import { PlusCircle, Hospital, User, UserCog, Building2, Activity, Edit, Eye, Trash2, MapPin, Phone, Mail, Clock, Loader2, FileSpreadsheet, CreditCard, Search, Calendar, Stethoscope, RefreshCw, Settings, FileText } from "lucide-react";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/queryClient";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
@@ -22,7 +22,7 @@ import { Slider } from "@/components/ui/slider";
 import { Label } from "@/components/ui/label";
 import SuperAdminExportReports from "@/components/SuperAdminExportReports";
 import RefundManagement from "@/components/RefundManagement";
-import { useAdminConfig } from "@/hooks/use-app-config";
+import { useAdminConfig, useAdminBookingConfig } from "@/hooks/use-app-config";
 import PolicyEditor from "@/components/super-admin/PolicyEditor";
 
 // Clinic schema with admin user fields
@@ -36,9 +36,11 @@ const clinicSchema = z.object({
   phone: z.string().min(1, "Phone number is required"),
   email: z.string().email("Invalid email address"),
   openingHours: z.string().min(1, "Opening hours are required"),
+  latitude: z.string().min(1, "Latitude is required"),
+  longitude: z.string().min(1, "Longitude is required"),
   description: z.string().optional(),
   imageUrl: z.string().optional(),
-  
+
   // Clinic admin user fields
   adminUsername: z.string().min(1, "Admin username is required"),
   adminPassword: z.string().min(6, "Admin password must be at least 6 characters"),
@@ -58,9 +60,11 @@ const editClinicSchema = z.object({
   phone: z.string().min(1, "Phone number is required"),
   email: z.string().email("Invalid email address"),
   openingHours: z.string().min(1, "Opening hours are required"),
+  latitude: z.string().min(1, "Latitude is required"),
+  longitude: z.string().min(1, "Longitude is required"),
   description: z.string().optional(),
   imageUrl: z.string().optional(),
-  
+
   // Clinic admin user fields (optional for updates)
   adminUsername: z.string().optional(),
   adminPassword: z.string().optional(),
@@ -339,6 +343,8 @@ export default function SuperAdminDashboard() {
       phone: "",
       email: "",
       openingHours: "",
+      latitude: "",
+      longitude: "",
       description: "",
       imageUrl: "",
       adminUsername: "",
@@ -506,6 +512,8 @@ export default function SuperAdminDashboard() {
     form.setValue('phone', clinic.phone);
     form.setValue('email', clinic.email);
     form.setValue('openingHours', clinic.openingHours);
+    form.setValue('latitude', clinic.latitude || '');
+    form.setValue('longitude', clinic.longitude || '');
     form.setValue('description', clinic.description || '');
     form.setValue('imageUrl', clinic.imageUrl || '');
     // Fetch clinic with admin data to pre-populate admin fields (password intentionally left blank)
@@ -665,6 +673,35 @@ export default function SuperAdminDashboard() {
                               <FormLabel>Zip Code</FormLabel>
                               <FormControl>
                                 <Input placeholder="Zip Code" {...field} />
+                              </FormControl>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+                      </div>
+
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <FormField
+                          control={form.control}
+                          name="latitude"
+                          render={({ field }) => (
+                            <FormItem>
+                              <FormLabel>Latitude</FormLabel>
+                              <FormControl>
+                                <Input placeholder="e.g. 9.9252" {...field} />
+                              </FormControl>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+                        <FormField
+                          control={form.control}
+                          name="longitude"
+                          render={({ field }) => (
+                            <FormItem>
+                              <FormLabel>Longitude</FormLabel>
+                              <FormControl>
+                                <Input placeholder="e.g. 78.1198" {...field} />
                               </FormControl>
                               <FormMessage />
                             </FormItem>
@@ -1241,6 +1278,85 @@ export default function SuperAdminDashboard() {
       return <NearbySettingsComponent />;
     }
 
+    if (selectedMenuItem === "booking-settings") {
+      const BookingSettingsComponent = () => {
+        const { configurations, isLoading, updateConfigurations, isUpdating } = useAdminBookingConfig();
+        const [timeoutSeconds, setTimeoutSeconds] = useState(300);
+        const { toast } = useToast();
+
+        useEffect(() => {
+          if (configurations && configurations.length > 0) {
+            const timeoutConfig = configurations.find((c: any) => c.configKey === 'token_reservation_timeout_seconds');
+            if (timeoutConfig) setTimeoutSeconds(parseInt(timeoutConfig.configValue));
+          }
+        }, [configurations]);
+
+        const handleSave = async () => {
+          try {
+            await updateConfigurations({ token_reservation_timeout_seconds: timeoutSeconds.toString() });
+            toast({ title: "Settings saved", description: `Reservation timeout updated to ${timeoutSeconds}s` });
+          } catch (err) {
+            toast({ title: "Failed to save", description: "Could not update settings. Please try again.", variant: "destructive" });
+          }
+        };
+
+        if (isLoading) {
+          return <div className="p-6 flex items-center justify-center"><Loader2 className="h-6 w-6 animate-spin" /></div>;
+        }
+
+        return (
+          <div className="p-6 max-w-2xl">
+            <div className="mb-6">
+              <h1 className="text-2xl font-bold text-gray-900">Booking Settings</h1>
+              <p className="text-gray-600 mt-1">Configure token reservation and booking timing</p>
+            </div>
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg">Walk-in Token Reservation</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                <div>
+                  <Label className="text-base font-medium">Reservation Timeout (seconds)</Label>
+                  <p className="text-sm text-muted-foreground mt-1 mb-3">
+                    How long a walk-in token is held before it expires if the attender doesn't confirm the booking. Currently: <strong>{timeoutSeconds}s ({Math.floor(timeoutSeconds / 60)}m {timeoutSeconds % 60}s)</strong>
+                  </p>
+                  <div className="flex items-center gap-3">
+                    <Input
+                      type="number"
+                      min={30}
+                      max={1800}
+                      value={timeoutSeconds}
+                      onChange={(e) => setTimeoutSeconds(Math.max(30, Math.min(1800, parseInt(e.target.value) || 300)))}
+                      className="w-40"
+                    />
+                    <span className="text-sm text-muted-foreground">seconds (min: 30, max: 1800)</span>
+                  </div>
+                  <div className="flex gap-2 mt-3">
+                    {[60, 120, 180, 300, 600].map(s => (
+                      <Button key={s} variant={timeoutSeconds === s ? "default" : "outline"} size="sm" onClick={() => setTimeoutSeconds(s)}>
+                        {s < 60 ? `${s}s` : `${s / 60}m`}
+                      </Button>
+                    ))}
+                  </div>
+                </div>
+              </CardContent>
+              <CardFooter className="border-t pt-4">
+                <Button onClick={handleSave} disabled={isUpdating}>
+                  {isUpdating ? (
+                    <><Loader2 className="mr-2 h-4 w-4 animate-spin" />Saving...</>
+                  ) : (
+                    <><Settings className="mr-2 h-4 w-4" />Save Settings</>
+                  )}
+                </Button>
+              </CardFooter>
+            </Card>
+          </div>
+        );
+      };
+
+      return <BookingSettingsComponent />;
+    }
+
     // Default dashboard view
     return (
       <div className="p-6">
@@ -1634,6 +1750,28 @@ export default function SuperAdminDashboard() {
                 </p>
                 <p className={`text-xs ${selectedMenuItem === "nearby-settings" ? "text-blue-600" : "text-gray-500"}`}>
                   Configure nearby mode
+                </p>
+              </div>
+            </button>
+
+            {/* Booking Settings Option */}
+            <button
+              onClick={() => setSelectedMenuItem("booking-settings")}
+              className={`w-full text-left px-3 py-3 rounded-lg mb-2 transition-all duration-200 flex items-center group ${
+                selectedMenuItem === "booking-settings"
+                  ? "bg-blue-50 text-blue-700 border-l-4 border-blue-600"
+                  : "text-gray-700 hover:bg-gray-50 hover:text-gray-900"
+              }`}
+            >
+              <span className={`mr-3 ${selectedMenuItem === "booking-settings" ? "text-blue-600" : "text-gray-500 group-hover:text-gray-700"}`}>
+                <Settings className="h-5 w-5" />
+              </span>
+              <div className="flex-1">
+                <p className={`font-medium text-sm ${selectedMenuItem === "booking-settings" ? "text-blue-700" : ""}`}>
+                  Booking Settings
+                </p>
+                <p className={`text-xs ${selectedMenuItem === "booking-settings" ? "text-blue-600" : "text-gray-500"}`}>
+                  Token reservation & timing
                 </p>
               </div>
             </button>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -136,6 +136,22 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  // Seed default system configurations (runs once on startup)
+  (async () => {
+    try {
+      await storage.upsertConfiguration({
+        configKey: 'token_reservation_timeout_seconds',
+        configValue: '300',
+        configType: 'number',
+        description: 'How long (in seconds) a walk-in token reservation is held before it expires',
+        category: 'booking',
+        isEditable: true,
+      });
+    } catch (err) {
+      console.error('Failed to seed default configurations:', err);
+    }
+  })();
+
   // Get public configurations (no authentication required)
   app.get("/api/configurations/public", async (req, res) => {
     try {
@@ -1201,9 +1217,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
     if (!req.user || req.user.role !== "super_admin") return res.sendStatus(403);
     try {
       // Validate the combined data
-      const { 
+      const {
         name, address, city, state, zipCode, phone, email, openingHours, description, imageUrl,
-        adminUsername, adminPassword, adminName, adminPhone, adminEmail 
+        latitude, longitude,
+        adminUsername, adminPassword, adminName, adminPhone, adminEmail
       } = req.body;
 
       // Validate required fields
@@ -1217,7 +1234,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       // Create clinic first
       const clinicData = {
-        name, address, city, state, zipCode, phone, email, openingHours, description, imageUrl
+        name, address, city, state, zipCode, phone, email, openingHours, description, imageUrl,
+        latitude: latitude || null,
+        longitude: longitude || null
       };
       
       const clinic = await storage.createClinic(clinicData);

--- a/server/services/eta.ts
+++ b/server/services/eta.ts
@@ -650,9 +650,26 @@ export class ETAService {
         // Base = now (no one being seen, next patient should be called immediately)
         liveEstimatedStartTime = addMinutes(now, patientsAhead * avgConsultationTime);
       } else {
-        // Doctor hasn't started yet — use stored value, but never show a past time
-        const stored = estimatedStartTime ? new Date(estimatedStartTime) : null;
-        liveEstimatedStartTime = (stored && stored > now) ? stored : now;
+        // Doctor hasn't started yet, nothing in progress, nothing completed
+        // Still need to count token_started patients ahead in the queue
+        const aheadCount = await db
+          .select({ count: sql<number>`COUNT(*)::integer` })
+          .from(appointments)
+          .where(
+            and(
+              eq(appointments.scheduleId, scheduleId),
+              inArray(appointments.status, ["token_started", "scheduled"]),
+              sql`${appointments.tokenNumber} < ${tokenNumber}`
+            )
+          );
+        const patientsAhead = aheadCount[0]?.count || 0;
+        if (patientsAhead > 0) {
+          liveEstimatedStartTime = addMinutes(now, patientsAhead * avgConsultationTime);
+        } else {
+          // No one ahead — use stored value, but never show a past time
+          const stored = estimatedStartTime ? new Date(estimatedStartTime) : null;
+          liveEstimatedStartTime = (stored && stored > now) ? stored : now;
+        }
       }
     }
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -4986,6 +4986,25 @@ export class DatabaseStorage implements IStorage {
     }
   }
 
+  async upsertConfiguration(config: InsertAdminConfiguration): Promise<AdminConfiguration> {
+    const [result] = await db
+      .insert(adminConfigurations)
+      .values(config)
+      .onConflictDoUpdate({
+        target: adminConfigurations.configKey,
+        // Update value and type — seed is the authoritative source for configType
+        set: {
+          configValue: config.configValue,
+          configType: config.configType,
+          description: config.description,
+          category: config.category,
+          updatedAt: new Date(),
+        },
+      })
+      .returning();
+    return result;
+  }
+
   // Mark appointment as refunded to prevent duplicate refunds
   async markAppointmentAsRefunded(appointmentId: number, refundAmount: number): Promise<void> {
     try {
@@ -5033,8 +5052,10 @@ export class DatabaseStorage implements IStorage {
     const maxRes = resResult[0]?.maxToken || 0;
     const nextToken = Math.max(maxAppt, maxRes) + 1;
 
-    // 4. Create reservation with 5-minute expiry
-    const expiresAt = new Date(Date.now() + 5 * 60 * 1000);
+    // 4. Read timeout from config (default 300 seconds)
+    const timeoutConfig = await this.getConfiguration('token_reservation_timeout_seconds');
+    const timeoutSeconds = timeoutConfig ? parseInt(timeoutConfig.configValue) : 300;
+    const expiresAt = new Date(Date.now() + timeoutSeconds * 1000);
     const [reservation] = await db.insert(tokenReservations).values({
       scheduleId,
       tokenNumber: nextToken,


### PR DESCRIPTION
## Summary
- Fix ETA calculation for walk-in tokens: correctly counts queued patients ahead when no one is in_progress and nothing is completed yet
- Add mandatory Latitude/Longitude fields to Add/Edit Clinic form in super admin dashboard
- Add configurable walk-in token reservation timeout via Super Admin → Booking Settings
  - Default 300s, adjustable from 30s to 1800s
  - Attender dashboard countdown timer uses the configured value
  - Toast feedback on save (success/error)

## Test plan
- [ ] Attender dashboard: add multiple walk-in tokens and verify ETA increments correctly per position in queue
- [ ] Super Admin → Add New Clinic: confirm Latitude and Longitude are required fields (validation error if blank)
- [ ] Super Admin → Edit Clinic: confirm Latitude and Longitude are pre-populated
- [ ] Super Admin → Booking Settings: change timeout, click Save Settings, verify toast appears
- [ ] Create a new walk-in reservation and confirm it expires after the configured timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)