### PR TITLE
feat: ETA config, expired walk-in tokens, MDT SMS OTP, and bug fixes

### DIFF
--- a/client/src/components/clinic-admin/EtaConfigDialog.tsx
+++ b/client/src/components/clinic-admin/EtaConfigDialog.tsx
@@ -1,0 +1,161 @@
+// Dialog for clinic admin to set avg consultation time per doctor
+import { useState, useEffect, useRef } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Loader2, Timer } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+import { apiRequest } from "@/lib/queryClient";
+
+interface EtaConfigDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  doctor: { id: number; name: string } | null;
+  clinicId: number;
+}
+
+const QUICK_OPTIONS = [5, 10, 15, 20, 30];
+
+export function EtaConfigDialog({ open, onOpenChange, doctor, clinicId }: EtaConfigDialogProps) {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [minutes, setMinutes] = useState<number | "">(15);
+  const [error, setError] = useState("");
+  const prevOpen = useRef(false);
+
+  const { data: details, isLoading } = useQuery({
+    queryKey: ["doctor-details", doctor?.id],
+    queryFn: async () => {
+      const res = await apiRequest("GET", `/api/doctors/${doctor!.id}/details`);
+      return res.json();
+    },
+    enabled: open && !!doctor,
+  });
+
+  useEffect(() => {
+    if (open && !prevOpen.current) {
+      // Reset to saved value each time dialog opens
+      setMinutes(details?.consultationDuration ?? 15);
+      setError("");
+    }
+    prevOpen.current = open;
+  }, [open, details]);
+
+  const mutation = useMutation({
+    mutationFn: async (consultationMinutes: number) => {
+      const res = await apiRequest(
+        "PATCH",
+        `/api/clinics/${clinicId}/doctors/${doctor!.id}/consultation-time`,
+        { consultationMinutes }
+      );
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.message || "Failed to update");
+      }
+      return res.json();
+    },
+    onSuccess: (_, consultationMinutes) => {
+      toast({
+        title: "ETA updated",
+        description: `${doctor?.name} set to ${consultationMinutes} min/patient`,
+      });
+      queryClient.invalidateQueries({ queryKey: ["doctor-details", doctor?.id] });
+      onOpenChange(false);
+    },
+    onError: (err: Error) => {
+      toast({
+        title: "Failed to update",
+        description: err.message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const handleSave = () => {
+    const val = Number(minutes);
+    if (!minutes || isNaN(val) || val < 1 || val > 120) {
+      setError("Please enter a valid time between 1 and 120 minutes.");
+      return;
+    }
+    setError("");
+    mutation.mutate(val);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Timer className="h-5 w-5 text-blue-500" />
+            Set Consultation Time — {doctor?.name}
+          </DialogTitle>
+        </DialogHeader>
+
+        {isLoading ? (
+          <div className="flex justify-center py-6">
+            <Loader2 className="h-6 w-6 animate-spin" />
+          </div>
+        ) : (
+          <div className="space-y-4 py-2">
+            <div>
+              <Label className="text-sm font-medium">
+                Avg consultation time (minutes)
+              </Label>
+              <p className="text-xs text-muted-foreground mt-1 mb-3">
+                This sets the base ETA for all patients in this doctor's queue today and future schedules.
+              </p>
+              <div className="flex items-center gap-2">
+                <Input
+                  type="number"
+                  min={1}
+                  max={120}
+                  value={minutes}
+                  onChange={(e) => {
+                    const raw = e.target.value;
+                    const parsed = parseInt(raw);
+                    setMinutes(raw === "" ? "" : isNaN(parsed) ? "" : parsed);
+                    setError("");
+                  }}
+                  className="w-24"
+                  placeholder="e.g. 15"
+                />
+                <span className="text-sm text-muted-foreground">minutes</span>
+              </div>
+              {error && <p className="text-xs text-destructive mt-1">{error}</p>}
+            </div>
+            <div>
+              <Label className="text-xs text-muted-foreground">Quick select</Label>
+              <div className="flex gap-2 mt-2">
+                {QUICK_OPTIONS.map((opt) => (
+                  <Button
+                    key={opt}
+                    variant={minutes === opt ? "default" : "outline"}
+                    size="sm"
+                    onClick={() => setMinutes(opt)}
+                  >
+                    {opt}m
+                  </Button>
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={mutation.isPending || isLoading}>
+            {mutation.isPending ? (
+              <><Loader2 className="mr-2 h-4 w-4 animate-spin" />Saving...</>
+            ) : (
+              "Save"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/eta-display.tsx
+++ b/client/src/components/eta-display.tsx
@@ -12,6 +12,9 @@ interface ETADisplayProps {
 }
 
 function getStageInfo(status: string, doctorHasArrived: boolean, avgConsultationTime?: number) {
+  if (status === "expired") {
+    return { label: "Expired", variant: "destructive" as const, description: "Walk-in reservation expired", isLive: false };
+  }
   if (status === "token_started" && !doctorHasArrived) {
     return { label: "Scheduled", variant: "outline" as const, description: "Based on scheduled start time", isLive: false };
   }

--- a/client/src/components/mobile-login-firebase.tsx
+++ b/client/src/components/mobile-login-firebase.tsx
@@ -4,7 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { useLocation } from "wouter";
 import { useToast } from "@/hooks/use-toast";
-import { apiRequest } from "@/lib/queryClient";
+import { apiRequest, queryClient } from "@/lib/queryClient";
 import { firebaseAuth } from "@/lib/firebase";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -149,10 +149,11 @@ export function MobileLoginFirebase() {
         if (!res.ok) {
           throw new Error(result.message || 'Failed to verify OTP');
         }
+        queryClient.setQueryData(["/api/user"], result);
       }
 
       toast({ title: "Success!", description: "Login successful" });
-      setTimeout(() => navigate('/'), 500);
+      navigate('/');
     } catch (error) {
       toast({
         title: "Error",

--- a/client/src/pages/attender-dashboard.tsx
+++ b/client/src/pages/attender-dashboard.tsx
@@ -1032,11 +1032,15 @@ export default function AttenderDashboard() {
                                                     }
                                                   </td>
                                                   <td className="py-4 px-4">
-                                                    <ETADisplay 
-                                                      appointmentId={appointment.id} 
-                                                      tokenNumber={appointment.tokenNumber}
-                                                      className="text-xs"
-                                                    />
+                                                    {appointment.status === "expired" ? (
+                                                      <span className="text-xs text-muted-foreground">—</span>
+                                                    ) : (
+                                                      <ETADisplay
+                                                        appointmentId={appointment.id}
+                                                        tokenNumber={appointment.tokenNumber}
+                                                        className="text-xs"
+                                                      />
+                                                    )}
                                                   </td>
                                                   <td className="py-4 px-4">
                                                     <Badge
@@ -1047,6 +1051,7 @@ export default function AttenderDashboard() {
                                                         appointment.status === "pause" ? "destructive" :
                                                         appointment.status === "cancel" ? "destructive" :
                                                         appointment.status === "no_show" ? "destructive" :
+                                                        appointment.status === "expired" ? "destructive" :
                                                         appointment.status === "token_started" ? "outline" :
                                                         "outline"
                                                       }
@@ -1059,6 +1064,7 @@ export default function AttenderDashboard() {
                                                       appointment.status === "cancel" ? "Cancelled" :
                                                       appointment.status === "no_show" ? "No Show" :
                                                       appointment.status === "completed" ? "Completed" :
+                                                      appointment.status === "expired" ? "Expired" :
                                                       "Unknown"}
                                                     </Badge>
                                                     {appointment.statusNotes && (

--- a/client/src/pages/auth-page.tsx
+++ b/client/src/pages/auth-page.tsx
@@ -8,7 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useToast } from "@/hooks/use-toast";
-import { apiRequest } from "@/lib/queryClient";
+import { apiRequest, queryClient } from "@/lib/queryClient";
 import { z } from "zod";
 import React, { useState, useEffect, useRef } from "react";
 import { Phone, Lock, User, Mail, Loader2, AlertCircle } from "lucide-react";
@@ -353,13 +353,15 @@ function MobileLoginForm() {
         throw new Error(result.message || 'Failed to verify OTP');
       }
 
+      // Update auth cache so the app recognises the session immediately
+      queryClient.setQueryData(["/api/user"], result);
+
       toast({
         title: "Success!",
         description: "Login successful",
       });
 
-      // Navigate to home after successful login
-      setTimeout(() => navigate('/'), 500);
+      navigate('/');
     } catch (error) {
       toast({
         title: "Error",

--- a/client/src/pages/clinic-admin-dashboard.tsx
+++ b/client/src/pages/clinic-admin-dashboard.tsx
@@ -43,6 +43,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { specialties } from '@shared/schema';
 import { ExportReport } from '@/components/ExportReport';
+import { EtaConfigDialog } from '@/components/clinic-admin/EtaConfigDialog';
 
 // Define interfaces for the data types
 interface Clinic {
@@ -187,6 +188,10 @@ export default function ClinicAdminDashboard() {
   const [selectedAttender, setSelectedAttender] = useState<Attender | null>(null);
   const [attenderId, setAttenderId] = useState<number | null>(null);
   
+  // ETA config dialog state
+  const [isEtaDialogOpen, setIsEtaDialogOpen] = useState(false);
+  const [etaDoctor, setEtaDoctor] = useState<Doctor | null>(null);
+
   // File upload state
   const [doctorImageFile, setDoctorImageFile] = useState<File | null>(null);
   const [doctorImagePreview, setDoctorImagePreview] = useState<string>("");
@@ -1195,8 +1200,19 @@ export default function ClinicAdminDashboard() {
                         </div>
                       </div>
                         <div className="flex gap-2">
-                          <Button 
-                            variant="outline" 
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="text-blue-600 hover:bg-blue-50"
+                            onClick={() => {
+                              setEtaDoctor(doctor);
+                              setIsEtaDialogOpen(true);
+                            }}
+                          >
+                            <Clock className="h-4 w-4 mr-1" /> ETA
+                          </Button>
+                          <Button
+                            variant="outline"
                             size="sm"
                             onClick={() => {
                               setSelectedDoctor(doctor);
@@ -1215,8 +1231,8 @@ export default function ClinicAdminDashboard() {
                           >
                             <Edit className="h-4 w-4 mr-1" /> Edit
                           </Button>
-                          <Button 
-                            variant="outline" 
+                          <Button
+                            variant="outline"
                             size="sm"
                             className="text-red-600 hover:bg-red-50"
                             onClick={() => {
@@ -1666,6 +1682,13 @@ export default function ClinicAdminDashboard() {
       </Dialog>
       
       {/* Delete Doctor Dialog */}
+      <EtaConfigDialog
+        open={isEtaDialogOpen}
+        onOpenChange={setIsEtaDialogOpen}
+        doctor={etaDoctor}
+        clinicId={params?.id ? parseInt(params.id) : user?.clinicId || 0}
+      />
+
       <Dialog open={isDeleteDoctorDialogOpen} onOpenChange={setIsDeleteDoctorDialogOpen}>
         <DialogContent className="sm:max-w-[400px]">
           <DialogHeader>

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,6 +3,7 @@ import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 import { createServer } from "net";
+import { storage } from "./storage";
 
 // Function to find an available port
 async function findAvailablePort(startPort: number): Promise<number> {
@@ -88,4 +89,13 @@ const port = await findAvailablePort(desiredPort);
   server.listen(port, "0.0.0.0", () => {
     log(`serving on port ${port}${port !== desiredPort ? ` (fallback from ${desiredPort})` : ''}`);
   });
+
+  // Periodically expire stale walk-in token reservations (every 60 seconds)
+  setInterval(async () => {
+    try {
+      await storage.expireStaleReservations();
+    } catch (err) {
+      console.error('Error expiring stale reservations:', err);
+    }
+  }, 60_000);
 })();

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -4,13 +4,13 @@ import cors from 'cors';
 import { storage, getTokens } from './storage';
 import { createSessionMiddleware, setupAuth } from './auth';
 import { insertAppointmentSchema, insertAttenderDoctorSchema, insertClinicSchema, insertUserSchema, type AttenderDoctor, type User } from "../shared/schema";
-import { insertDoctorDetailSchema, appointments } from "../shared/schema";
+import { insertDoctorDetailSchema, appointments, doctorSchedules } from "../shared/schema";
 import { z } from "zod";
 import { notificationService } from './services/notification';
 import { ETAService } from './services/eta';
 import { walletService } from './services/wallet';
 import { db } from './db';
-import { eq, and, sql, isNull, not } from 'drizzle-orm';
+import { eq, and, sql, isNull, not, gte } from 'drizzle-orm';
 import { scrypt, randomBytes } from "crypto";
 import { promisify } from "util";
 
@@ -1544,10 +1544,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   // Get doctor details
   app.get("/api/doctors/:id/details", async (req, res) => {
+    if (!req.user) return res.sendStatus(401);
     try {
       const doctorId = parseInt(req.params.id);
-      
-      // Get doctor details
       const details = await storage.getDoctorDetails(doctorId);
       
       if (!details) {
@@ -1589,6 +1588,39 @@ export async function registerRoutes(app: Express): Promise<Server> {
     } catch (error) {
       console.error("Error updating doctor details:", error);
       res.status(500).json({ message: "Failed to update doctor details" });
+    }
+  });
+
+  // Clinic admin: configure avg consultation time per doctor
+  app.patch("/api/clinics/:clinicId/doctors/:doctorId/consultation-time", async (req, res) => {
+    if (!req.user || req.user.role !== "clinic_admin") return res.sendStatus(403);
+    try {
+      const clinicId = parseInt(req.params.clinicId);
+      const doctorId = parseInt(req.params.doctorId);
+      const { consultationMinutes } = z.object({
+        consultationMinutes: z.number().int().min(1).max(120),
+      }).parse(req.body);
+
+      await storage.updateDoctorDetails(doctorId, { consultationDuration: consultationMinutes });
+
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      await db
+        .update(doctorSchedules)
+        .set({ averageConsultationTime: consultationMinutes })
+        .where(
+          and(
+            eq(doctorSchedules.doctorId, doctorId),
+            eq(doctorSchedules.clinicId, clinicId),
+            eq(doctorSchedules.isActive, true),
+            gte(doctorSchedules.date, today)
+          )
+        );
+
+      res.json({ success: true, consultationMinutes });
+    } catch (error) {
+      console.error("Error updating consultation time:", error);
+      res.status(400).json({ message: error instanceof Error ? error.message : "Failed to update" });
     }
   });
 
@@ -1789,16 +1821,30 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(400).json({ error: "Invalid schedule ID" });
       }
 
-      await storage.completeSchedule(scheduleId);
-
-      // Get all appointments for this schedule that are not completed or cancelled
-      const appointments = await storage.getAppointmentsBySchedule(scheduleId);
-      const affectedAppointments = appointments.filter(apt => 
-        !['completed', 'cancel'].includes(apt.status || '')
+      // Capture waiting patients BEFORE any status changes
+      const allAppointments = await storage.getAppointmentsBySchedule(scheduleId);
+      const waitingAppointments = allAppointments.filter(apt =>
+        !['completed', 'no_show', 'cancel'].includes(apt.status || '')
       );
 
-      // Notify patients about schedule completion
-      for (const appointment of affectedAppointments) {
+      // Refund paid patients first, then cancel remaining + mark complete
+      try {
+        const refundResult = await walletService.processScheduleCancellationRefunds(
+          scheduleId,
+          'Schedule completed by clinic admin',
+          req.user.id
+        );
+        if (refundResult.refundedAppointments > 0) {
+          console.log(`Refunded ${refundResult.refundedAppointments} appointments (₹${refundResult.totalRefundAmount}) on schedule completion`);
+        }
+      } catch (refundError) {
+        console.error('Refund processing failed during schedule completion:', refundError);
+      }
+
+      await storage.completeSchedule(scheduleId);
+
+      // Notify all patients who were still waiting
+      for (const appointment of waitingAppointments) {
         if (appointment.patientId) {
           await notificationService.createNotification({
             userId: appointment.patientId,
@@ -2042,8 +2088,23 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(400).json({ message: 'Invalid schedule ID' });
       }
 
+      // Process refunds BEFORE deleting — once deleted, scheduleId is nulled on appointments
+      try {
+        const refundResult = await walletService.processScheduleCancellationRefunds(
+          scheduleId,
+          'Schedule was deleted by clinic admin',
+          req.user.id
+        );
+        if (refundResult.refundedAppointments > 0) {
+          console.log(`Refunded ${refundResult.refundedAppointments} appointments (₹${refundResult.totalRefundAmount}) for deleted schedule ${scheduleId}`);
+        }
+      } catch (refundError) {
+        console.error('Refund processing failed during schedule deletion:', refundError);
+        // Continue with deletion even if refunds fail
+      }
+
       const result = await storage.deleteDoctorSchedule(scheduleId);
-      
+
       // Send notifications to patients about cancelled appointments
       if (result.cancelledAppointments.length > 0) {
         console.log(`Sending notifications for ${result.cancelledAppointments.length} cancelled appointments`);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -774,7 +774,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
         "hold": ["in_progress", "cancel", "no_show"], // Patient not arrived, can start or cancel
         "cancel": [], // Terminal state
         "no_show": [], // Terminal state
-        "completed": [] // Terminal state
+        "completed": [], // Terminal state
+        "expired": [] // Terminal state — walk-in reservation expired
       };
 
       if (!validTransitions[currentStatus]?.includes(status)) {

--- a/server/services/sms.ts
+++ b/server/services/sms.ts
@@ -1,15 +1,13 @@
+// SMS service — My Dreams Technology provider with mock fallback for development
 import { randomInt } from 'crypto';
 
-// SMS Provider Interface
 interface SMSProvider {
   sendSMS(to: string, message: string): Promise<void>;
 }
 
-// Mock SMS Provider for development
 class MockSMSProvider implements SMSProvider {
   async sendSMS(to: string, message: string): Promise<void> {
     console.log(`[MOCK SMS] Sending to ${to}: ${message}`);
-    // In development, log the OTP to console
     const otpMatch = message.match(/\b\d{6}\b/);
     if (otpMatch) {
       console.log(`[MOCK SMS] OTP Code: ${otpMatch[0]}`);
@@ -17,95 +15,85 @@ class MockSMSProvider implements SMSProvider {
   }
 }
 
-// Twilio SMS Provider (requires environment variables)
-class TwilioSMSProvider implements SMSProvider {
-  private twilioClient: any;
-  private fromNumber: string;
+class MyDreamsTechSMSProvider implements SMSProvider {
+  private readonly apiKey: string;
+  private readonly senderId: string;
+  private readonly templateId: string;
+  private readonly endpoint = 'http://app.mydreamstechnology.in/vb/apikey.php';
 
   constructor() {
-    const accountSid = process.env.TWILIO_ACCOUNT_SID;
-    const authToken = process.env.TWILIO_AUTH_TOKEN;
-    this.fromNumber = process.env.TWILIO_PHONE_NUMBER || '';
-
-    if (accountSid && authToken) {
-      // Only import Twilio if credentials are provided
-      try {
-        const twilio = require('twilio');
-        this.twilioClient = twilio(accountSid, authToken);
-      } catch (error) {
-        console.error('Twilio SDK not installed. Please run: npm install twilio');
-        throw new Error('Twilio SDK not available');
-      }
-    } else {
-      throw new Error('Twilio credentials not configured');
-    }
+    this.apiKey = process.env.MDT_SMS_API_KEY || 'z2dPfGJmu1UOWev9';
+    this.senderId = process.env.MDT_SMS_SENDER_ID || 'PLATRR';
+    this.templateId = process.env.MDT_SMS_TEMPLATE_ID || '1707176121738738158';
   }
 
   async sendSMS(to: string, message: string): Promise<void> {
+    const params = new URLSearchParams({
+      apikey: this.apiKey,
+      senderid: this.senderId,
+      number: to,
+      message,
+      templateid: this.templateId,
+    });
+
+    const url = `${this.endpoint}?${params.toString()}`;
+    const response = await fetch(url);
+    const text = await response.text();
+
+    let success = false;
     try {
-      await this.twilioClient.messages.create({
-        body: message,
-        from: this.fromNumber,
-        to: to
-      });
-      console.log(`SMS sent successfully to ${to}`);
-    } catch (error) {
-      console.error('Failed to send SMS via Twilio:', error);
-      throw new Error('Failed to send SMS');
+      const json = JSON.parse(text);
+      success = json?.status?.toLowerCase() === 'success';
+    } catch {
+      success = text.trim().toUpperCase() === 'SENT';
     }
+
+    if (!success) {
+      console.error(`[MDT SMS] Failed for ${to}: ${text}`);
+      throw new Error(`SMS delivery failed: ${text}`);
+    }
+    console.log(`[MDT SMS] Sent to ${to}`);
   }
 }
 
-// SMS Service class
 class SMSService {
   private provider: SMSProvider;
 
   constructor() {
-    // Use Twilio in production if configured, otherwise use mock
-    if (process.env.NODE_ENV === 'production' && process.env.TWILIO_ACCOUNT_SID) {
-      try {
-        this.provider = new TwilioSMSProvider();
-        console.log('SMS Service: Using Twilio provider');
-      } catch (error) {
-        console.warn('Twilio not configured, falling back to mock provider');
-        this.provider = new MockSMSProvider();
-      }
-    } else {
+    if (process.env.MDT_SMS_MOCK === 'true') {
       this.provider = new MockSMSProvider();
-      console.log('SMS Service: Using mock provider (development mode)');
+      console.log('SMS Service: Using mock provider');
+    } else {
+      this.provider = new MyDreamsTechSMSProvider();
+      console.log('SMS Service: Using My Dreams Technology provider');
     }
   }
 
-  // Generate a 6-digit OTP
   generateOTP(): string {
     return randomInt(100000, 999999).toString();
   }
 
-  // Send OTP to phone number
   async sendOTP(phoneNumber: string, otp: string): Promise<void> {
-    const message = `Your ClinicFlow verification code is: ${otp}. This code will expire in 10 minutes.`;
+    // Must match registered DLT template exactly (template ID: 1707176121738738158)
+    const message = `${otp} is your OTP to login. Valid for 10 minutes. Don't share this OTP with anyone. More details visit www.plattr.co.in - PLATTR`;
     await this.provider.sendSMS(phoneNumber, message);
   }
 
-  // Send appointment reminder
   async sendAppointmentReminder(phoneNumber: string, doctorName: string, appointmentTime: string): Promise<void> {
     const message = `Reminder: You have an appointment with Dr. ${doctorName} at ${appointmentTime}. Please arrive 10 minutes early.`;
     await this.provider.sendSMS(phoneNumber, message);
   }
 
-  // Send appointment confirmation
   async sendAppointmentConfirmation(phoneNumber: string, doctorName: string, appointmentTime: string, tokenNumber: number): Promise<void> {
     const message = `Your appointment with Dr. ${doctorName} is confirmed for ${appointmentTime}. Your token number is ${tokenNumber}.`;
     await this.provider.sendSMS(phoneNumber, message);
   }
 
-  // Send doctor arrival notification
   async sendDoctorArrivalNotification(phoneNumber: string, doctorName: string): Promise<void> {
     const message = `Dr. ${doctorName} has arrived and consultations have started. Please be ready when your token is called.`;
     await this.provider.sendSMS(phoneNumber, message);
   }
 
-  // Send token progress notification
   async sendTokenProgressNotification(phoneNumber: string, currentToken: number, yourToken: number): Promise<void> {
     const tokensAway = yourToken - currentToken;
     const message = `Current token: ${currentToken}. Your token: ${yourToken}. You are ${tokensAway} tokens away. Please be ready.`;
@@ -113,5 +101,4 @@ class SMSService {
   }
 }
 
-// Export singleton instance
 export const smsService = new SMSService();

--- a/server/services/wallet.ts
+++ b/server/services/wallet.ts
@@ -93,43 +93,46 @@ export class WalletService {
     } = transactionData;
     
     try {
-      // Get or create wallet
+      // Get or create wallet (outside tx — just to obtain wallet.id)
       const wallet = await this.getOrCreateWallet(patientId);
-      const currentBalance = parseFloat(wallet.balance);
-      
-      // Calculate new balance
-      let newBalance: number;
-      let totalEarned = parseFloat(wallet.totalEarned);
-      let totalSpent = parseFloat(wallet.totalSpent);
-      
-      // Determine if this is a debit or credit transaction
+
+      // Determine credit vs debit (pure logic, no DB)
       const isCredit = [
         'refund_schedule_cancel',
-        'refund_doctor_absent', 
+        'refund_doctor_absent',
         'partial_refund',
         'admin_credit',
         'wallet_topup'
       ].includes(transactionType);
-      
-      if (isCredit) {
-        newBalance = currentBalance + amount;
-        if (transactionType.includes('refund')) {
-          totalEarned += amount;
-        }
-      } else {
-        // Debit transaction
-        if (currentBalance < amount) {
-          throw new Error('Insufficient wallet balance');
-        }
-        newBalance = currentBalance - amount;
-        if (transactionType === 'appointment_payment') {
-          totalSpent += amount;
-        }
-      }
-      
-      // Start database transaction
+
+      // All balance work happens INSIDE the transaction with a row-level lock
       return await db.transaction(async (tx) => {
-        // Create wallet transaction record
+        // Lock the wallet row to prevent concurrent balance modifications
+        const [lockedWallet] = await tx.select()
+          .from(patientWallets)
+          .where(eq(patientWallets.id, wallet.id))
+          .for('update');
+
+        const currentBalance = parseFloat(lockedWallet.balance);
+        let totalEarned = parseFloat(lockedWallet.totalEarned);
+        let totalSpent = parseFloat(lockedWallet.totalSpent);
+        let newBalance: number;
+
+        if (isCredit) {
+          newBalance = currentBalance + amount;
+          if (transactionType.includes('refund')) {
+            totalEarned += amount;
+          }
+        } else {
+          if (currentBalance < amount) {
+            throw new Error('Insufficient wallet balance');
+          }
+          newBalance = currentBalance - amount;
+          if (transactionType === 'appointment_payment') {
+            totalSpent += amount;
+          }
+        }
+
         const [transaction] = await tx.insert(walletTransactions)
           .values({
             walletId: wallet.id,
@@ -147,8 +150,7 @@ export class WalletService {
             metadata: metadata ? JSON.stringify(metadata) : null
           })
           .returning();
-        
-        // Update wallet balance
+
         await tx.update(patientWallets)
           .set({
             balance: newBalance.toFixed(2),
@@ -157,12 +159,12 @@ export class WalletService {
             updatedAt: new Date()
           })
           .where(eq(patientWallets.id, wallet.id));
-        
+
         console.log(`Processed ${transactionType} transaction: ₹${amount} for patient ${patientId}. New balance: ₹${newBalance}`);
-        
+
         return transaction;
       });
-      
+
     } catch (error) {
       console.error('Error processing wallet transaction:', error);
       throw error;
@@ -425,8 +427,8 @@ export class WalletService {
             eq(appointments.isRefundEligible, true),
             eq(appointments.hasBeenRefunded, false),
             eq(appointments.isPaid, true),
-            // Only refund waiting patients — not completed/cancelled/no-show
-            eq(appointments.status, 'token_started')
+            // Refund all waiting patients (token_started, hold, pause, scheduled)
+            sql`${appointments.status} NOT IN ('completed', 'no_show', 'cancel')`
           )
         );
       

--- a/server/services/wallet.ts
+++ b/server/services/wallet.ts
@@ -221,7 +221,7 @@ export class WalletService {
             eq(appointments.hasBeenRefunded, false),
             eq(appointments.isPaid, true),
             // Only refund appointments that haven't been completed
-            sql`${appointments.status} NOT IN ('completed', 'no_show')`
+            sql`${appointments.status} NOT IN ('completed', 'no_show', 'expired')`
           )
         );
       
@@ -428,7 +428,7 @@ export class WalletService {
             eq(appointments.hasBeenRefunded, false),
             eq(appointments.isPaid, true),
             // Refund all waiting patients (token_started, hold, pause, scheduled)
-            sql`${appointments.status} NOT IN ('completed', 'no_show', 'cancel')`
+            sql`${appointments.status} NOT IN ('completed', 'no_show', 'cancel', 'expired')`
           )
         );
       

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -349,13 +349,19 @@ export class DatabaseStorage implements IStorage {
   }
 
   async completeSchedule(scheduleId: number): Promise<void> {
-    await db
-      .update(doctorSchedules)
-      .set({
-        scheduleStatus: 'completed',
-        completedAt: sql`CURRENT_TIMESTAMP`
-      })
-      .where(eq(doctorSchedules.id, scheduleId));
+    await db.transaction(async (tx) => {
+      // Cancel any remaining non-terminal appointments (walk-ins, unpaid, etc.)
+      await tx.update(appointments)
+        .set({ status: 'cancel', statusNotes: 'Schedule completed' })
+        .where(and(
+          eq(appointments.scheduleId, scheduleId),
+          sql`${appointments.status} NOT IN ('completed', 'no_show', 'cancel')`
+        ));
+
+      await tx.update(doctorSchedules)
+        .set({ scheduleStatus: 'completed', completedAt: sql`CURRENT_TIMESTAMP` })
+        .where(eq(doctorSchedules.id, scheduleId));
+    });
   }
 
   async closeScheduleBooking(scheduleId: number): Promise<void> {
@@ -2693,7 +2699,7 @@ export class DatabaseStorage implements IStorage {
   }
 
   async updateDoctorDetails(
-    doctorId: number, 
+    doctorId: number,
     details: Partial<{
       consultationFee: number | string;
       consultationDuration: number;
@@ -2702,10 +2708,22 @@ export class DatabaseStorage implements IStorage {
       registrationNumber: string;
     }>
   ): Promise<DoctorDetail> {
-    // Convert consultationFee to string if it's a number
     const updatedDetails = { ...details };
     if (typeof updatedDetails.consultationFee === 'number') {
       updatedDetails.consultationFee = updatedDetails.consultationFee.toString();
+    }
+
+    const existing = await this.getDoctorDetails(doctorId);
+    if (!existing) {
+      const [inserted] = await db.insert(doctorDetails).values({
+        doctorId,
+        consultationFee: (updatedDetails.consultationFee as string) ?? "0",
+        consultationDuration: updatedDetails.consultationDuration ?? 15,
+        qualifications: updatedDetails.qualifications,
+        experience: updatedDetails.experience,
+        registrationNumber: updatedDetails.registrationNumber,
+      }).returning();
+      return inserted;
     }
 
     const [updated] = await db

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -148,7 +148,7 @@ export interface IStorage {
   getAttendersByRole(): Promise<User[]>;
   updateAppointmentStatus(
     appointmentId: number, 
-    status: "scheduled" | "in_progress" | "hold" | "pause" | "cancel" | "no_show" | "completed", 
+    status: "scheduled" | "in_progress" | "hold" | "pause" | "cancel" | "no_show" | "completed" | "expired",
     statusNotes?: string
   ): Promise<Appointment>;
   updateDoctorAvailability(
@@ -351,11 +351,12 @@ export class DatabaseStorage implements IStorage {
   async completeSchedule(scheduleId: number): Promise<void> {
     await db.transaction(async (tx) => {
       // Cancel any remaining non-terminal appointments (walk-ins, unpaid, etc.)
+      // Exclude 'expired' — those are already terminal placeholder records
       await tx.update(appointments)
         .set({ status: 'cancel', statusNotes: 'Schedule completed' })
         .where(and(
           eq(appointments.scheduleId, scheduleId),
-          sql`${appointments.status} NOT IN ('completed', 'no_show', 'cancel')`
+          sql`${appointments.status} NOT IN ('completed', 'no_show', 'cancel', 'expired')`
         ));
 
       await tx.update(doctorSchedules)
@@ -2619,7 +2620,7 @@ export class DatabaseStorage implements IStorage {
       console.log('Last appointment in any state:', lastAppointment);
 
       // If all appointments are in a non-active state, queue hasn't started yet
-      const inactiveStatuses = ['scheduled', 'cancel', 'no_show'];
+      const inactiveStatuses = ['scheduled', 'cancel', 'no_show', 'expired'];
       if (inactiveStatuses.includes(lastAppointment.status)) {
         return {
           currentToken: 0,
@@ -2895,9 +2896,29 @@ export class DatabaseStorage implements IStorage {
       }
     });
 
-    // Add current token count to each schedule based on its own appointments
+    // Also count pending (non-expired) reservations per schedule
+    const scheduleIds = schedules.map(s => s.id);
+    const pendingReservations = scheduleIds.length > 0
+      ? await db.select({ scheduleId: tokenReservations.scheduleId, count: count() })
+          .from(tokenReservations)
+          .where(and(
+            inArray(tokenReservations.scheduleId, scheduleIds),
+            eq(tokenReservations.status, "pending"),
+            gt(tokenReservations.expiresAt, new Date())
+          ))
+          .groupBy(tokenReservations.scheduleId)
+      : [];
+
+    const pendingReservationCount = new Map<number, number>();
+    pendingReservations.forEach(r => {
+      pendingReservationCount.set(r.scheduleId, r.count);
+    });
+
+    // Add current token count to each schedule (appointments + pending reservations)
     schedules.forEach(schedule => {
-      schedule.currentTokenCount = scheduleAppointmentCount.get(schedule.id) || 0;
+      const apptCount = scheduleAppointmentCount.get(schedule.id) || 0;
+      const resCount = pendingReservationCount.get(schedule.id) || 0;
+      schedule.currentTokenCount = apptCount + resCount;
     });
 
     // Calculate available slots - exclude completed schedules and closed bookings
@@ -3276,8 +3297,8 @@ export class DatabaseStorage implements IStorage {
           lt(appointments.tokenNumber, patientToken),
           gte(appointments.date, startOfDay),
           lte(appointments.date, endOfDay),
-          // Only count active appointments (not cancelled)
-          not(eq(appointments.status, "cancel"))
+          // Only count active appointments (not cancelled or expired placeholders)
+          sql`${appointments.status} NOT IN ('cancel', 'expired')`
         )
       );
     
@@ -5047,9 +5068,49 @@ export class DatabaseStorage implements IStorage {
   // --- Token Reservation Methods ---
 
   async expireStaleReservations(): Promise<void> {
-    await db.update(tokenReservations)
-      .set({ status: "expired" })
-      .where(and(eq(tokenReservations.status, "pending"), lt(tokenReservations.expiresAt, new Date())));
+    const stale = await db.select()
+      .from(tokenReservations)
+      .where(and(
+        eq(tokenReservations.status, "pending"),
+        lt(tokenReservations.expiresAt, new Date())
+      ));
+
+    for (const reservation of stale) {
+      // Guard: skip if an appointment already exists for this token (e.g. confirmed just at boundary)
+      const [existing] = await db.select({ id: appointments.id })
+        .from(appointments)
+        .where(and(
+          eq(appointments.scheduleId, reservation.scheduleId),
+          eq(appointments.tokenNumber, reservation.tokenNumber),
+          ne(appointments.status, "cancel")
+        ));
+
+      if (!existing) {
+        const [schedule] = await db.select()
+          .from(doctorSchedules)
+          .where(eq(doctorSchedules.id, reservation.scheduleId));
+
+        if (schedule) {
+          await db.insert(appointments).values({
+            doctorId: schedule.doctorId,
+            clinicId: schedule.clinicId,
+            scheduleId: reservation.scheduleId,
+            date: new Date(schedule.date + 'T00:00:00.000Z'),
+            tokenNumber: reservation.tokenNumber,
+            guestName: 'Walk-in (expired)',
+            isWalkIn: true,
+            status: 'expired',
+            isPaid: false,
+            isRefundEligible: false,
+            hasBeenRefunded: false,
+          });
+        }
+      }
+
+      await db.update(tokenReservations)
+        .set({ status: "expired" })
+        .where(eq(tokenReservations.id, reservation.id));
+    }
   }
 
   async reserveNextToken(scheduleId: number, reservedByUserId: number): Promise<TokenReservation> {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -98,7 +98,8 @@ export const appointmentStatuses = [
   "pause",         // Temporarily paused appointment (was in progress)
   "cancel",        // Appointment cancelled
   "no_show",       // Patient didn't show up (not eligible for refund)
-  "completed"      // Appointment completed
+  "completed",     // Appointment completed
+  "expired"        // Walk-in reservation expired without confirmation — placeholder to fill queue gap
 ] as const;
 
 export type AppointmentStatus = typeof appointmentStatuses[number];


### PR DESCRIPTION
## Summary

- **ETA Config**: Clinic admin can set consultation duration; free-form input with validation, stale pre-fill fix
- **Expired walk-in tokens**: Stale reservations now create `expired` placeholder appointments to keep queue gapless; ETA and refund logic exclude expired tokens
- **Refund safety**: Schedule delete and complete now trigger refunds for waiting patients; wallet race condition fixed with row-level lock
- **MDT SMS OTP**: Replaced Twilio with My Dreams Technology SMS provider; DLT-compliant OTP template
- **OTP login redirect fix**: Auth cache updated immediately after OTP verify so redirect to dashboard works without page refresh
- **Token count consistency**: Home page and book page now show matching available token counts (pending reservations included)
- **UI**: Expired appointments show "Expired" badge instead of "Live" in attender dashboard

## Test plan

- [ ] Clinic admin can configure ETA duration from the ETA config dialog
- [ ] Walk-in reservation expiry creates expired placeholder and keeps queue gapless
- [ ] ETA for patients behind an expired token is calculated correctly
- [ ] Deleting or completing a schedule refunds waiting patients
- [ ] OTP sent via MDT SMS provider and received on real phone
- [ ] OTP login redirects to dashboard immediately without refresh
- [ ] Home page available count matches book page token count

🤖 Generated with [Claude Code](https://claude.com/claude-code)