### PR TITLE
fix: clear cancelReason when re-activating cancelled schedule

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2028,8 +2028,14 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(404).json({ message: 'Schedule not found' });
       }
 
+      // Clear cancelReason when re-activating a cancelled schedule
+      const updateData: any = { ...validData };
+      if (validData.isActive === true && currentSchedule.cancelReason) {
+        updateData.cancelReason = null;
+      }
+
       // Update the schedule
-      const schedule = await storage.updateDoctorSchedule(scheduleId, validData);
+      const schedule = await storage.updateDoctorSchedule(scheduleId, updateData);
       if (!schedule) {
         return res.status(404).json({ message: 'Schedule not found' });
       }


### PR DESCRIPTION
## Summary
- When a cancelled schedule is re-activated via the **Start Booking** toggle in the edit form, the `cancelReason` field was never cleared in the DB
- This caused `getAttenderSchedulesToday` to still return `cancelled` status even though `isActive` was set back to `true`
- Fix: in `PATCH /api/doctors/schedules/:id`, when `isActive: true` is set and the schedule has an existing `cancelReason`, we now include `cancelReason: null` in the update to clear it

## Root Cause
Two different logic paths were out of sync:
- **Schedules List page** reads `isActive` directly → showed "Active" correctly after re-activation
- **Attender Dashboard** (`getAttenderSchedulesToday`) checks `cancelReason` first → kept showing "Cancelled" because it was never cleared

## Test plan
- [ ] Cancel a schedule from the attender dashboard (Manage Tokens → Cancel Schedule)
- [ ] Verify Attender Dashboard shows "Cancelled" badge
- [ ] Go to Doctor Schedules → edit the schedule → ensure "Start Booking" is ON → click Update Schedule
- [ ] Verify Attender Dashboard now shows correct active status (e.g. "Token Started") instead of "Cancelled"

🤖 Generated with [Claude Code](https://claude.com/claude-code)