### PR TITLE
fix: completed schedule action guard and ETA timezone bug

### DIFF
--- a/client/src/pages/attender-dashboard.tsx
+++ b/client/src/pages/attender-dashboard.tsx
@@ -902,7 +902,7 @@ export default function AttenderDashboard() {
                                           <Button
                                             variant={getPresenceData(doctorData.doctor.id, schedule.id).hasArrived ? "default" : "outline"}
                                             className="gap-2"
-                                            disabled={getPresenceData(doctorData.doctor.id, schedule.id).hasArrived}
+                                            disabled={getPresenceData(doctorData.doctor.id, schedule.id).hasArrived || schedule.scheduleStatus === 'completed'}
                                             onClick={() => handleToggleDoctorArrival(
                                               doctorData.doctor.id,
                                               schedule.clinicId || doctorData.clinicId || user?.clinicId,
@@ -935,6 +935,7 @@ export default function AttenderDashboard() {
                                             variant="outline"
                                             size="sm"
                                             className="gap-2"
+                                            disabled={schedule.scheduleStatus === 'completed'}
                                             onClick={() => handleToggleBooking(schedule.id, schedule.bookingStatus)}
                                           >
                                             {schedule.bookingStatus === 'closed' ? 'Open Booking' : 'Close Booking'}
@@ -943,6 +944,7 @@ export default function AttenderDashboard() {
                                               <Button
                                                 variant="outline"
                                                 size="sm"
+                                                disabled={schedule.scheduleStatus === 'completed'}
                                                 onClick={() => handleToggleSchedulePause(schedule.id, !schedule.isPaused)}
                                               >
                                                 {schedule.isPaused ? "Resume Schedule" : "Pause Schedule"}
@@ -951,6 +953,7 @@ export default function AttenderDashboard() {
                                                 variant="outline"
                                                 size="sm"
                                                 className="hover:bg-red-500 hover:text-white"
+                                                disabled={schedule.scheduleStatus === 'completed'}
                                                 onClick={() => handleCancelSchedule(schedule.id)}
                                               >
                                                 Cancel Schedule
@@ -960,10 +963,11 @@ export default function AttenderDashboard() {
                                               variant="outline"
                                               size="sm"
                                               className="gap-2"
+                                              disabled={schedule.scheduleStatus === 'completed'}
                                               onClick={() => openWalkInDialog(
-                                                doctorData.doctor.id, 
-                                                doctorData.doctor.name, 
-                                                schedule.clinicId, 
+                                                doctorData.doctor.id,
+                                                doctorData.doctor.name,
+                                                schedule.clinicId,
                                                 schedule.id
                                               )}
                                             >

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1743,6 +1743,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(400).json({ error: "Invalid request body" });
       }
 
+      const [sched] = await db.select({ scheduleStatus: doctorSchedules.scheduleStatus }).from(doctorSchedules).where(eq(doctorSchedules.id, scheduleId)).limit(1);
+      if (!sched || sched.scheduleStatus === 'completed') {
+        return res.status(400).json({ error: "Cannot modify a completed schedule" });
+      }
+
       await storage.pauseSchedule(scheduleId, pauseReason, new Date(date));
 
       // Get all appointments for this schedule that are scheduled or in progress
@@ -1780,6 +1785,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
     try {
       const scheduleId = parseInt(req.params.id);
+      const [sched] = await db.select({ scheduleStatus: doctorSchedules.scheduleStatus }).from(doctorSchedules).where(eq(doctorSchedules.id, scheduleId)).limit(1);
+      if (!sched || sched.scheduleStatus === 'completed') {
+        return res.status(400).json({ error: "Cannot modify a completed schedule" });
+      }
       await storage.resumeSchedule(scheduleId);
 
       // Get all appointments for this schedule that are in paused status
@@ -1875,6 +1884,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(400).json({ error: "Invalid schedule ID" });
       }
 
+      const [sched] = await db.select({ scheduleStatus: doctorSchedules.scheduleStatus }).from(doctorSchedules).where(eq(doctorSchedules.id, scheduleId)).limit(1);
+      if (!sched || sched.scheduleStatus === 'completed') {
+        return res.status(400).json({ error: "Cannot modify a completed schedule" });
+      }
+
       await storage.closeScheduleBooking(scheduleId);
       res.json({ message: "Booking closed for schedule successfully" });
     } catch (error) {
@@ -1891,6 +1905,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const scheduleId = parseInt(req.params.id);
       if (isNaN(scheduleId)) {
         return res.status(400).json({ error: "Invalid schedule ID" });
+      }
+
+      const [sched] = await db.select({ scheduleStatus: doctorSchedules.scheduleStatus }).from(doctorSchedules).where(eq(doctorSchedules.id, scheduleId)).limit(1);
+      if (!sched || sched.scheduleStatus === 'completed') {
+        return res.status(400).json({ error: "Cannot modify a completed schedule" });
       }
 
       await storage.openScheduleBooking(scheduleId);
@@ -2426,6 +2445,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
     if (!req.user || !['attender', 'clinic_admin'].includes(req.user.role)) return res.sendStatus(403);
     try {
       const scheduleId = parseInt(req.params.scheduleId);
+      const [sched] = await db.select({ scheduleStatus: doctorSchedules.scheduleStatus }).from(doctorSchedules).where(eq(doctorSchedules.id, scheduleId)).limit(1);
+      if (!sched || sched.scheduleStatus === 'completed') {
+        return res.status(400).json({ error: "Cannot add walk-in to a completed schedule" });
+      }
       const reservation = await storage.reserveNextToken(scheduleId, req.user.id);
       res.status(201).json(reservation);
     } catch (error) {

--- a/server/services/eta.ts
+++ b/server/services/eta.ts
@@ -17,6 +17,16 @@ export interface ETACalculationResult {
 
 export class ETAService {
   private static DEFAULT_CONSULTATION_TIME = 15; // Default 15 minutes per consultation
+  private static IST_OFFSET_MINUTES = 330; // UTC+5:30
+
+  // Builds a UTC Date for a schedule's start/end time string ("HH:MM" in IST) on a given date.
+  private static parseScheduleTime(timeStr: string, scheduleDate: Date): Date {
+    const [hours, minutes] = timeStr.split(':').map(Number);
+    const d = new Date(scheduleDate);
+    const utcMinutes = hours * 60 + minutes - this.IST_OFFSET_MINUTES;
+    d.setUTCHours(Math.floor(utcMinutes / 60), utcMinutes % 60, 0, 0);
+    return d;
+  }
 
   /**
    * Returns the effective average consultation time for ETA calculations.
@@ -99,10 +109,8 @@ export class ETAService {
     const { startTime } = schedule[0];
     const avgTime = this.getEffectiveAvgTime(schedule[0].averageConsultationTime, schedule[0].learnedConsultationTime);
 
-    // Parse schedule start time
-    const [hours, minutes] = startTime.split(':').map(Number);
-    const baseTime = new Date(scheduleDate);
-    baseTime.setHours(hours, minutes, 0, 0);
+    // Parse schedule start time (stored as IST "HH:MM", convert to UTC)
+    const baseTime = this.parseScheduleTime(startTime, scheduleDate);
     
     // Calculate ETA: scheduleStartTime + (tokenNumber - 1) * avgConsultTime
     // If schedule start time is already past, use current time as base
@@ -420,9 +428,7 @@ export class ETAService {
           .limit(1);
         
         if (schedule.length > 0) {
-          const [hours, minutes] = schedule[0].startTime.split(':').map(Number);
-          const scheduleStart = new Date(schedule[0].date);
-          scheduleStart.setHours(hours, minutes, 0, 0);
+          const scheduleStart = this.parseScheduleTime(schedule[0].startTime, new Date(schedule[0].date));
           actualStartTime = addMinutes(scheduleStart, (completedAppointment[0].tokenNumber - 1) * this.DEFAULT_CONSULTATION_TIME);
           console.log(`📍 Estimated start time based on schedule: ${format(actualStartTime, 'HH:mm')}`);
         } else {
@@ -724,9 +730,9 @@ export class ETAService {
         if (patientsAhead > 0) {
           liveEstimatedStartTime = addMinutes(now, patientsAhead * avgConsultationTime);
         } else {
-          // No one ahead — use stored value, but never show a past time
-          const stored = estimatedStartTime ? new Date(estimatedStartTime) : null;
-          liveEstimatedStartTime = (stored && stored > now) ? stored : now;
+          // No one ahead — use schedule start time (IST-aware), not the stale stored value
+          const scheduleStart = this.parseScheduleTime(schedule[0].startTime, new Date(schedule[0].date));
+          liveEstimatedStartTime = scheduleStart > now ? scheduleStart : now;
         }
       }
     }
@@ -894,9 +900,7 @@ export class ETAService {
     if (actualArrivalTime) {
       baseTime = new Date(actualArrivalTime);
     } else {
-      const [hours, minutes] = startTime.split(':').map(Number);
-      baseTime = new Date(date);
-      baseTime.setHours(hours, minutes, 0, 0);
+      baseTime = this.parseScheduleTime(startTime, new Date(date));
     }
 
     // Get all non-completed appointments


### PR DESCRIPTION
## Summary

- **Completed schedule action guard**: All action buttons (Mark as Arrived, Close/Open Booking, Pause/Resume Schedule, Cancel Schedule, New Walk-in) are now disabled on the frontend when a schedule is marked as completed
- **Server-side guards**: Added completed schedule validation on `pause`, `resume`, `booking-close`, `booking-open`, and `reserve-token` routes — returns `400` if schedule is already completed
- **ETA timezone fix**: Schedule times stored as IST "HH:MM" were being interpreted as UTC on the production server, causing a 15:00 schedule to show 8:30 PM ETA instead of 3:00 PM. Added `parseScheduleTime()` helper that correctly converts IST to UTC (subtracts 5h30m offset)
- **ETA first patient fix**: `getAppointmentETA` live calculation for the first patient (no one ahead, nothing started) now uses the schedule start time directly instead of the stale stored ETA value

## Test plan

- [ ] Mark a schedule as completed — verify all action buttons are disabled
- [ ] Try calling pause/resume/booking-close/booking-open/reserve-token APIs on a completed schedule — verify `400` response
- [ ] Create a schedule for 15:00 and book the first patient — verify ETA shows 3:00 PM, not 8:30 PM
- [ ] Verify ETA updates correctly when doctor arrives and consultations start

🤖 Generated with [Claude Code](https://claude.com/claude-code)