### PR TITLE
fix: use schedule start time as ETA base for future schedules

### DIFF
--- a/server/services/eta.ts
+++ b/server/services/eta.ts
@@ -727,13 +727,10 @@ export class ETAService {
             )
           );
         const patientsAhead = aheadCount[0]?.count || 0;
-        if (patientsAhead > 0) {
-          liveEstimatedStartTime = addMinutes(now, patientsAhead * avgConsultationTime);
-        } else {
-          // No one ahead — use schedule start time (IST-aware), not the stale stored value
-          const scheduleStart = this.parseScheduleTime(schedule[0].startTime, new Date(schedule[0].date));
-          liveEstimatedStartTime = scheduleStart > now ? scheduleStart : now;
-        }
+        // Base from schedule start time (IST-aware) — not 'now' — since nothing has started yet
+        const scheduleStart = this.parseScheduleTime(schedule[0].startTime, new Date(schedule[0].date));
+        const baseTime = scheduleStart > now ? scheduleStart : now;
+        liveEstimatedStartTime = addMinutes(baseTime, patientsAhead * avgConsultationTime);
       }
     }
 


### PR DESCRIPTION
## Summary

- **ETA wrong for walk-in/queued patients on future schedules**: When a schedule hasn't started yet (no in_progress, no completed tokens), ETA for patients with others ahead in the queue was using `now` as the base time. This caused tokens 2, 3, etc. on a 15:00 schedule to show ETAs like 12:47 PM, 1:02 PM instead of 3:15 PM, 3:30 PM.
- **Fix**: In `getAppointmentETA`, the "nothing started yet" branch now uses `scheduleStart` as the base time (IST-aware via `parseScheduleTime`), falling back to `now` only if the schedule start time is already past.

## Example

Schedule: 15:00 - 17:00, current time: 12:32 PM

| Token | Before fix | After fix |
|-------|-----------|-----------|
| 1 | 3:00 PM ✅ | 3:00 PM ✅ |
| 2 | 12:47 PM ❌ | 3:15 PM ✅ |
| 3 | 1:02 PM ❌ | 3:30 PM ✅ |

## Test plan

- [ ] Create a future schedule (e.g. 15:00 - 17:00), book 3 patients before the schedule starts — verify ETAs show 3:00, 3:15, 3:30 PM
- [ ] Add walk-in patients to a future schedule — verify ETA is based on schedule start, not current time
- [ ] Verify ETA still works correctly once consultations have started (in_progress / completed branches unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)