### PR TITLE
feat: add get directions button and clarify aerial distance labels

### DIFF
--- a/client/src/components/clinic-card.tsx
+++ b/client/src/components/clinic-card.tsx
@@ -1,6 +1,6 @@
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Building2, MapPin } from "lucide-react";
+import { Building2, MapPin, Navigation } from "lucide-react";
 import { Link } from "wouter";
 import React from "react";
 
@@ -11,10 +11,18 @@ interface ClinicCardProps {
     address: string;
     imageUrl?: string;
     specialties?: string[];
+    latitude?: number | string | null;
+    longitude?: number | string | null;
   };
 }
 
+function getDirectionsUrl(lat?: number | string | null, lng?: number | string | null) {
+  if (!lat || !lng) return null;
+  return `https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}`;
+}
+
 export function ClinicCard({ clinic }: ClinicCardProps) {
+  const directionsUrl = getDirectionsUrl(clinic.latitude, clinic.longitude);
   return (
     <Card className="overflow-hidden hover:shadow-md transition-shadow">
       <CardHeader className="p-0">
@@ -55,13 +63,21 @@ export function ClinicCard({ clinic }: ClinicCardProps) {
             )}
           </div>
         </div>
-        <div className="mt-6">
+        <div className="mt-6 flex flex-col gap-2">
           <Button asChild className="w-full">
             <Link href={`/patient/clinics/${clinic.id}`}>
               <Building2 className="mr-2 h-4 w-4" />
               View Doctors
             </Link>
           </Button>
+          {directionsUrl && (
+            <Button asChild variant="outline" className="w-full">
+              <a href={directionsUrl} target="_blank" rel="noopener noreferrer">
+                <Navigation className="mr-2 h-4 w-4" />
+                Get Directions
+              </a>
+            </Button>
+          )}
         </div>
       </CardContent>
     </Card>

--- a/client/src/components/nav-header.tsx
+++ b/client/src/components/nav-header.tsx
@@ -8,7 +8,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { LogOut, User, Calendar, UserPlus, Clock, Star, MapPin } from "lucide-react";
+import { LogOut, User, Calendar, UserPlus, Clock, Star } from "lucide-react";
 import { NotificationPopover } from "./notifications/notification-popover";
 import { CompactNavigationButtons } from "./navigation-buttons";
 import { CompactWallet } from "./wallet/compact-wallet";
@@ -81,23 +81,15 @@ export function NavHeader() {
                 </Button>
               )}
                */}
-              {/* Show map and favorites links for patients */}
+              {/* Show favorites and wallet for patients */}
               {user?.role === "patient" && (
                 <>
                   <Button variant="ghost" asChild className="hidden md:flex">
-                    <Link href="/map">
-                      <MapPin className="mr-2 h-4 w-4" />
-                      Find Near Me
+                    <Link href="/patient/favorites">
+                      <Star className="mr-2 h-4 w-4" />
+                      Favorites
                     </Link>
                   </Button>
-                  <>
-                  <Button variant="ghost" asChild className="hidden md:flex">
-                      <Link href="/patient/favorites">
-                        <Star className="mr-2 h-4 w-4" />
-                        Favorites
-                      </Link>
-                    </Button>
-                </>
                   <CompactWallet />
                 </>
               )}
@@ -166,20 +158,12 @@ export function NavHeader() {
                     </DropdownMenuItem>
                   )}
                   {user?.role === "patient" && (
-                    <>
-                      <DropdownMenuItem asChild>
-                        <Link href="/map" className="gap-2">
-                          <MapPin size={16} />
-                          <span>Find Near Me</span>
-                        </Link>
-                      </DropdownMenuItem>
-                      <DropdownMenuItem asChild>
-                        <Link href="/patient/favorites" className="gap-2">
-                          <Star size={16} />
-                          <span>Favorites</span>
-                        </Link>
-                      </DropdownMenuItem>
-                    </>
+                    <DropdownMenuItem asChild>
+                      <Link href="/patient/favorites" className="gap-2">
+                        <Star size={16} />
+                        <span>Favorites</span>
+                      </Link>
+                    </DropdownMenuItem>
                   )}
                   <DropdownMenuItem
                     className="gap-2 text-red-600"

--- a/client/src/components/ui/leaflet-map.tsx
+++ b/client/src/components/ui/leaflet-map.tsx
@@ -100,7 +100,7 @@ export function LeafletMap({
           ` : ''}
           ${hospital.distance ? `
             <div style="color: #059669; font-size: 12px; margin-bottom: 4px; font-weight: 500;">
-              📏 ${hospital.distance.toFixed(1)} km away
+              📏 ~${hospital.distance.toFixed(1)} km (aerial)
             </div>
           ` : ''}
           ${hospital.phone ? `

--- a/client/src/pages/map-page.tsx
+++ b/client/src/pages/map-page.tsx
@@ -281,15 +281,29 @@ export default function MapPage() {
                 ) : clinicsCount > 0 ? (
                   <div className="space-y-3">
                     {nearbyClinics.slice(0, 5).map((clinic) => (
-                      <div key={clinic.id} className="flex items-center justify-between p-3 border rounded-lg">
+                      <div key={clinic.id} className="flex items-center justify-between p-3 border rounded-lg gap-3">
                         <div>
                           <h4 className="font-medium">{clinic.name}</h4>
                           <p className="text-sm text-muted-foreground">{clinic.address}, {clinic.city}</p>
-                          <p className="text-xs text-green-600 font-medium">{clinic.distance.toFixed(1)} km away</p>
+                          <p className="text-xs text-green-600 font-medium">~{clinic.distance.toFixed(1)} km (aerial)</p>
                         </div>
-                        <Button variant="outline" size="sm" onClick={() => navigate(`/patient/clinics/${clinic.id}`)}>
-                          View Doctors
-                        </Button>
+                        <div className="flex flex-col gap-1 shrink-0">
+                          <Button variant="outline" size="sm" onClick={() => navigate(`/patient/clinics/${clinic.id}`)}>
+                            View Doctors
+                          </Button>
+                          {clinic.latitude && clinic.longitude && (
+                            <Button variant="outline" size="sm" asChild>
+                              <a
+                                href={`https://www.google.com/maps/dir/?api=1&destination=${clinic.latitude},${clinic.longitude}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                              >
+                                <Navigation className="mr-1 h-3 w-3" />
+                                Directions
+                              </a>
+                            </Button>
+                          )}
+                        </div>
                       </div>
                     ))}
                     {clinicsCount > 5 && (

--- a/client/src/pages/patient-dashboard.tsx
+++ b/client/src/pages/patient-dashboard.tsx
@@ -412,7 +412,7 @@ export default function PatientDashboard() {
                     <div className="flex items-center gap-2 flex-wrap">
                       <CardTitle className="text-lg">{result.name}</CardTitle>
                       <Badge className="bg-green-600 text-white text-xs">
-                        {result.distance.toFixed(1)} km away
+                        ~{result.distance.toFixed(1)} km (aerial)
                       </Badge>
                     </div>
                     <p className="text-sm text-gray-600 mt-1">{result.address}, {result.city}</p>
@@ -423,13 +423,27 @@ export default function PatientDashboard() {
                     )}
                   </div>
                 </div>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => toggleExpanded(`nearby-clinic-${result.id}`)}
-                >
-                  {isExpanded ? <ChevronDown /> : <ChevronRight />}
-                </Button>
+                <div className="flex items-center gap-1 shrink-0">
+                  {result.latitude && result.longitude && (
+                    <Button variant="outline" size="sm" asChild>
+                      <a
+                        href={`https://www.google.com/maps/dir/?api=1&destination=${result.latitude},${result.longitude}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <Navigation className="mr-1 h-3 w-3" />
+                        Directions
+                      </a>
+                    </Button>
+                  )}
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => toggleExpanded(`nearby-clinic-${result.id}`)}
+                  >
+                    {isExpanded ? <ChevronDown /> : <ChevronRight />}
+                  </Button>
+                </div>
               </div>
             </CardHeader>
             {isExpanded && (
@@ -486,7 +500,7 @@ export default function PatientDashboard() {
                   <CardTitle className="text-lg">{result.name}</CardTitle>
                   {result.distance !== null && result.distance !== undefined && (
                     <Badge className="bg-green-600 text-white text-xs">
-                      {result.distance.toFixed(1)} km away
+                      ~{result.distance.toFixed(1)} km (aerial)
                     </Badge>
                   )}
                   {result.type === 'specialty' && (
@@ -496,13 +510,27 @@ export default function PatientDashboard() {
                     <Badge variant="secondary">{result.doctors.length} doctors</Badge>
                   )}
                 </div>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => toggleExpanded(result.id)}
-                >
-                  {isExpanded ? <ChevronDown /> : <ChevronRight />}
-                </Button>
+                <div className="flex items-center gap-1 shrink-0">
+                  {result.latitude && result.longitude && (
+                    <Button variant="outline" size="sm" asChild>
+                      <a
+                        href={`https://www.google.com/maps/dir/?api=1&destination=${result.latitude},${result.longitude}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <Navigation className="mr-1 h-3 w-3" />
+                        Directions
+                      </a>
+                    </Button>
+                  )}
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => toggleExpanded(result.id)}
+                  >
+                    {isExpanded ? <ChevronDown /> : <ChevronRight />}
+                  </Button>
+                </div>
               </div>
             </CardHeader>
             {isExpanded && result.doctors && (
@@ -842,12 +870,14 @@ export default function PatientDashboard() {
                     name: clinic.name,
                     address: `${clinic.address}, ${clinic.city}`,
                     imageUrl: clinic.imageUrl || undefined,
-                    specialties: []
+                    specialties: [],
+                    latitude: clinic.latitude,
+                    longitude: clinic.longitude,
                   }} />
                   <Badge 
                     className="absolute top-2 right-2 bg-green-600 text-white"
                   >
-                    {clinic.distance.toFixed(1)} km away
+                    ~{clinic.distance.toFixed(1)} km (aerial)
                   </Badge>
                 </div>
               ))}

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -23,11 +23,12 @@ export async function setupVite(app: Express, server: Server) {
   // Dynamic imports so vite and its plugins are never loaded in production
   const { createServer: createViteServer, createLogger } = await import("vite");
   const { default: react } = await import("@vitejs/plugin-react");
+  const { default: themePlugin } = await import("@replit/vite-plugin-shadcn-theme-json");
   const viteLogger = createLogger();
 
   const vite = await createViteServer({
     root: path.resolve(__dirname, "..", "client"),
-    plugins: [react()],
+    plugins: [react(), themePlugin()],
     resolve: {
       alias: {
         "@": path.resolve(__dirname, "..", "client", "src"),


### PR DESCRIPTION
## Summary
- Add **Get Directions** button on clinic cards, search results, and map sidebar — opens Google Maps in a new tab with the clinic as destination and device location as origin
- Remove **Find Near Me** from patient header navigation
- Update all distance badges from `X km away` to `~X km (aerial)` to clarify straight-line vs road distance
- Restore shadcn theme plugin as dynamic import in dev server to fix missing UI colors

## Test plan
- [ ] Open patient dashboard — clinic cards should show "Get Directions" button below "View Doctors"
- [ ] Click "Get Directions" — should open Google Maps in a new tab with the clinic pinned as destination
- [ ] Search for a hospital — search result rows should show a "Directions" button next to the expand chevron
- [ ] Open map page sidebar — each clinic row should show a "Directions" button
- [ ] Verify distance badges show `~X km (aerial)` format everywhere
- [ ] Verify "Find Near Me" is gone from patient header
- [ ] Verify UI colors render correctly in dev (theme plugin restored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)