### PR TITLE
AUTH-002: OTP-verified patient registration, self-service Forgot MPIN & specialty filter fix

### DIFF
--- a/RouteMappy.postman_collection.json
+++ b/RouteMappy.postman_collection.json
@@ -149,6 +149,192 @@
 				}
 			},
 			"response": []
+		},
+		{
+			"name": "Auth - Patient Registration",
+			"item": [
+				{
+					"name": "Verify Phone (Registration OTP)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"phone\": \"9876543210\",\n    \"otp\": \"123456\"\n}"
+						},
+						"url": {
+							"raw": "{{baseUrl}}/api/register/verify-phone",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"register",
+								"verify-phone"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Patient Register",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"Test Patient\",\n    \"mobileNumber\": \"9876543210\",\n    \"mpin\": \"1234\"\n}"
+						},
+						"url": {
+							"raw": "{{baseUrl}}/api/auth/patient/register",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"auth",
+								"patient",
+								"register"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Auth - Forgot MPIN",
+			"item": [
+				{
+					"name": "Request OTP (Forgot MPIN)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"phone\": \"9876543210\"\n}"
+						},
+						"url": {
+							"raw": "{{baseUrl}}/api/auth/patient/forgot-mpin/request-otp",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"auth",
+								"patient",
+								"forgot-mpin",
+								"request-otp"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Verify OTP (Forgot MPIN)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"phone\": \"9876543210\",\n    \"otp\": \"123456\"\n}"
+						},
+						"url": {
+							"raw": "{{baseUrl}}/api/auth/patient/forgot-mpin/verify-otp",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"auth",
+								"patient",
+								"forgot-mpin",
+								"verify-otp"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Reset MPIN (Forgot MPIN)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"mobileNumber\": \"9876543210\",\n    \"newMpin\": \"5678\"\n}"
+						},
+						"url": {
+							"raw": "{{baseUrl}}/api/auth/patient/forgot-mpin/reset",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"auth",
+								"patient",
+								"forgot-mpin",
+								"reset"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Doctors",
+			"item": [
+				{
+					"name": "Get Specialties",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/api/specialties",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"specialties"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		}
+	],
+	"variable": [
+		{
+			"key": "baseUrl",
+			"value": "http://localhost:5001"
 		}
 	]
 }

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -6,6 +6,9 @@ const config: CapacitorConfig = {
   webDir: 'dist/public',
   server: {
     androidScheme: 'https',
+    // Load the live production site so relative /api calls hit the real backend
+    url: 'https://clinik.co.in',
+    cleartext: false,
   },
   plugins: {
     Geolocation: {

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -31,6 +31,7 @@ import { ForcePasswordReset } from "@/components/ForcePasswordReset";
 import PortalSelection from "@/pages/auth/portal-selection";
 import PatientLogin from "@/pages/auth/patient-login";
 import PatientRegister from "@/pages/auth/patient-register";
+import PatientForgotMpin from "@/pages/auth/patient-forgot-mpin";
 import StaffLogin from "@/pages/auth/staff-login";
 import AdminLogin from "@/pages/auth/admin-login";
 // Policy and help pages
@@ -99,6 +100,7 @@ function Router() {
       <Route path="/" component={getLandingPage} />
       <Route path="/patient-login" component={PatientLogin} />
       <Route path="/patient-register" component={PatientRegister} />
+      <Route path="/patient-forgot-mpin" component={PatientForgotMpin} />
       <Route path="/staff-login" component={StaffLogin} />
       <Route path="/admin-login" component={AdminLogin} />
       

--- a/client/src/components/mpin-keypad.tsx
+++ b/client/src/components/mpin-keypad.tsx
@@ -1,0 +1,96 @@
+// MPIN keypad: masked 4-digit display with an on-screen number pad for entry
+import { Lock } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+interface MpinKeypadProps {
+  value: string;
+  placeholder: string;
+  showToggle?: boolean;
+  reveal?: boolean;
+  onToggleReveal?: () => void;
+  onDigit: (digit: string) => void;
+  onClear: () => void;
+  onBackspace: () => void;
+}
+
+export function MpinKeypad({
+  value,
+  placeholder,
+  showToggle = false,
+  reveal = false,
+  onToggleReveal,
+  onDigit,
+  onClear,
+  onBackspace,
+}: MpinKeypadProps) {
+  const isFull = value.length >= 4;
+
+  return (
+    <div className="space-y-3">
+      <div className="relative">
+        <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-500" />
+        <Input
+          value={value}
+          type={reveal ? "text" : "password"}
+          placeholder={placeholder}
+          className="pl-10 text-center text-2xl tracking-[0.5em] font-bold placeholder:text-sm placeholder:tracking-normal placeholder:font-normal"
+          maxLength={4}
+          readOnly
+        />
+        {showToggle && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="absolute right-2 top-1/2 transform -translate-y-1/2"
+            onClick={onToggleReveal}
+          >
+            {reveal ? "Hide" : "Show"}
+          </Button>
+        )}
+      </div>
+
+      {/* Number pad */}
+      <div className="grid grid-cols-3 gap-2">
+        {[1, 2, 3, 4, 5, 6, 7, 8, 9].map((digit) => (
+          <Button
+            key={digit}
+            type="button"
+            variant="outline"
+            className="h-12 text-lg font-semibold"
+            onClick={() => onDigit(digit.toString())}
+            disabled={isFull}
+          >
+            {digit}
+          </Button>
+        ))}
+        <Button
+          type="button"
+          variant="outline"
+          className="h-12 text-sm"
+          onClick={onClear}
+        >
+          Clear
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          className="h-12 text-lg font-semibold"
+          onClick={() => onDigit("0")}
+          disabled={isFull}
+        >
+          0
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          className="h-12 text-sm"
+          onClick={onBackspace}
+        >
+          ←
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/nav-header.tsx
+++ b/client/src/components/nav-header.tsx
@@ -177,11 +177,11 @@ export function NavHeader() {
             </>
           ) : (
             <div className="flex items-center gap-2">
-              <Button variant="ghost" asChild>
-                <Link href="/auth">Login</Link>
+              <Button variant="outline" className="border-primary text-primary hover:bg-primary/10" asChild>
+                <Link href="/patient-register">Patient Register</Link>
               </Button>
               <Button asChild>
-                <Link href="/auth">Register</Link>
+                <Link href="/auth">Login</Link>
               </Button>
             </div>
           )}

--- a/client/src/components/otp-input.tsx
+++ b/client/src/components/otp-input.tsx
@@ -1,0 +1,53 @@
+// OTP digit-box input with auto-advance, backspace navigation, and paste support
+import { useRef } from "react";
+
+type OtpInputProps = {
+  digits: string[];
+  onChange: (digits: string[]) => void;
+};
+
+export function OtpInput({ digits, onChange }: OtpInputProps) {
+  const refs = useRef<(HTMLInputElement | null)[]>([]);
+  const count = digits.length;
+
+  return (
+    <div className="flex gap-2 justify-center">
+      {digits.map((digit, idx) => (
+        <input
+          key={idx}
+          ref={(el) => {
+            refs.current[idx] = el;
+          }}
+          type="text"
+          inputMode="numeric"
+          maxLength={1}
+          autoComplete="off"
+          value={digit}
+          className="w-10 h-12 text-center border border-input rounded-md text-lg focus:outline-none focus:ring-2 focus:ring-ring"
+          onChange={(e) => {
+            const val = e.target.value.replace(/\D/g, "").slice(-1);
+            const next = [...digits];
+            next[idx] = val;
+            onChange(next);
+            if (val && idx < count - 1) refs.current[idx + 1]?.focus();
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Backspace" && !digits[idx] && idx > 0) {
+              refs.current[idx - 1]?.focus();
+            }
+          }}
+          onPaste={(e) => {
+            e.preventDefault();
+            const pasted = e.clipboardData.getData("text").replace(/\D/g, "").slice(0, count);
+            const next = [...digits];
+            pasted.split("").forEach((ch, i) => {
+              if (i < count) next[i] = ch;
+            });
+            onChange(next);
+            refs.current[Math.min(pasted.length, count - 1)]?.focus();
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/client/src/components/search-filters.tsx
+++ b/client/src/components/search-filters.tsx
@@ -1,4 +1,6 @@
+// Doctor search bar + specialty filter driven by the specialties that actually exist in the DB
 import { Search } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -7,7 +9,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { specialties } from "@shared/schema";
 
 interface SearchFiltersProps {
   searchTerm: string;
@@ -22,6 +23,11 @@ export function SearchFilters({
   specialty,
   onSpecialtyChange,
 }: SearchFiltersProps) {
+  // Distinct specialties of existing doctors — keeps filter options in sync with real data
+  const { data: specialties = [] } = useQuery<string[]>({
+    queryKey: ["/api/specialties"],
+  });
+
   return (
     <div className="bg-white shadow-sm border-b">
       <div className="container mx-auto px-4 py-4">

--- a/client/src/pages/auth-page.tsx
+++ b/client/src/pages/auth-page.tsx
@@ -1,19 +1,13 @@
+// Staff/admin username+password login (/auth) with a pointer to the patient portal
 import { Link, useLocation } from "wouter";
 import { useAuth } from "@/hooks/use-auth";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { useToast } from "@/hooks/use-toast";
-import { apiRequest, queryClient } from "@/lib/queryClient";
 import { z } from "zod";
-import React, { useState, useEffect, useRef } from "react";
-import { Phone, Lock, User, Mail, Loader2, AlertCircle } from "lucide-react";
-import { Alert, AlertDescription } from "@/components/ui/alert";
-import { MobileLoginFirebase } from "@/components/mobile-login-firebase";
 
 // Simple schema for login
 const loginSchema = z.object({
@@ -23,34 +17,12 @@ const loginSchema = z.object({
 
 type LoginData = z.infer<typeof loginSchema>;
 
-// Simple schema for registration
-const registerSchema = z.object({
-  username: z.string().min(1, "Username is required"),
-  password: z.string().min(6, "Password must be at least 6 characters"),
-  confirmPassword: z.string(),
-  name: z.string().min(1, "Name is required"),
-  phone: z.string().min(1, "Phone number is required"),
-  email: z.string().email("Invalid email address").optional().or(z.literal("")),
-}).refine((data) => data.password === data.confirmPassword, {
-  message: "Passwords don't match",
-  path: ["confirmPassword"],
-});
-
-type RegisterData = z.infer<typeof registerSchema>;
-
 export default function AuthPage() {
   const [_location, navigate] = useLocation();
   const { user } = useAuth();
 
   if (user) {
-    // Redirect users based on their role
-    // if (user.role === "attender") {
-    //   navigate("/attender-dashboard");
-    // } else if (user.role === "super_admin") {
-    //   navigate("/super-admin-dashboard");
-    // } else {
-      navigate("/");
-    // }
+    navigate("/");
     return null;
   }
 
@@ -62,25 +34,7 @@ export default function AuthPage() {
             <CardTitle>Welcome to Clinik</CardTitle>
           </CardHeader>
           <CardContent>
-            <Tabs defaultValue="login">
-              <TabsList className="grid w-full grid-cols-3">
-                <TabsTrigger value="login">Login</TabsTrigger>
-                <TabsTrigger value="mobile-login">Mobile Login</TabsTrigger>
-                <TabsTrigger value="register">Register</TabsTrigger>
-              </TabsList>
-
-              <TabsContent value="login">
-                <LoginForm />
-              </TabsContent>
-
-              <TabsContent value="mobile-login">
-                <MobileLoginFirebase />
-              </TabsContent>
-
-              <TabsContent value="register">
-                <RegisterForm />
-              </TabsContent>
-            </Tabs>
+            <LoginForm />
           </CardContent>
         </Card>
       </div>
@@ -139,441 +93,19 @@ function LoginForm() {
         <Button type="submit" className="w-full" disabled={loginMutation.isPending}>
           Login
         </Button>
-      </form>
-    </Form>
-  );
-}
 
-function RegisterForm() {
-  const { registerMutation } = useAuth();
-  const form = useForm<RegisterData>({
-    resolver: zodResolver(registerSchema),
-    defaultValues: {
-      username: "",
-      password: "",
-      confirmPassword: "",
-      name: "",
-      phone: "",
-      email: "",
-    },
-  });
-
-  const onSubmit = (data: RegisterData) => {
-    // Remove confirmPassword and add patient-specific fields
-    const { confirmPassword, ...rest } = data;
-    registerMutation.mutate({
-      ...rest,
-      role: "patient",
-      specialty: null,
-      bio: null,
-      imageUrl: null,
-    });
-  };
-
-  return (
-    <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4 mt-4">
-        <FormField
-          control={form.control}
-          name="username"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Username</FormLabel>
-              <FormControl>
-                <Input {...field} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-        <FormField
-          control={form.control}
-          name="name"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Full Name</FormLabel>
-              <FormControl>
-                <Input {...field} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-        <FormField
-          control={form.control}
-          name="phone"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Phone Number*</FormLabel>
-              <FormControl>
-                <Input type="tel" {...field} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-        <FormField
-          control={form.control}
-          name="email"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Email (Optional)</FormLabel>
-              <FormControl>
-                <Input type="email" {...field} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-        <FormField
-          control={form.control}
-          name="password"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Password</FormLabel>
-              <FormControl>
-                <Input type="password" {...field} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-        <FormField
-          control={form.control}
-          name="confirmPassword"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Confirm Password</FormLabel>
-              <FormControl>
-                <Input type="password" {...field} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-        <Button type="submit" className="w-full" disabled={registerMutation.isPending}>
-          Register
-        </Button>
-      </form>
-    </Form>
-  );
-}
-
-// Mobile OTP Login schemas
-const mobileLoginRequestSchema = z.object({
-  phone: z.string().length(10, "Enter a valid 10-digit phone number").regex(/^\d+$/, "Only digits allowed"),
-});
-
-const mobileLoginVerifySchema = z.object({
-  phone: z.string().min(10, "Please enter a valid phone number"),
-  otp: z.string().length(6, "OTP must be 6 digits"),
-});
-
-type MobileLoginRequestData = z.infer<typeof mobileLoginRequestSchema>;
-type MobileLoginVerifyData = z.infer<typeof mobileLoginVerifySchema>;
-
-function MobileLoginForm() {
-  const [_location, navigate] = useLocation();
-  const { toast } = useToast();
-  const [step, setStep] = useState<'request' | 'verify'>('request');
-  const [phone, setPhone] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
-  const [countdown, setCountdown] = useState(0);
-  const [canResend, setCanResend] = useState(false);
-  const [otpDigits, setOtpDigits] = useState(['', '', '', '', '', '']);
-  const otpRefs = useRef<(HTMLInputElement | null)[]>([]);
-
-  // Countdown timer for OTP resend
-  useEffect(() => {
-    if (countdown > 0) {
-      const timer = setTimeout(() => setCountdown(countdown - 1), 1000);
-      return () => clearTimeout(timer);
-    } else if (countdown === 0 && step === 'verify') {
-      setCanResend(true);
-    }
-  }, [countdown, step]);
-
-  // Request OTP Form
-  const requestForm = useForm<MobileLoginRequestData>({
-    resolver: zodResolver(mobileLoginRequestSchema),
-    defaultValues: {
-      phone: '',
-    },
-  });
-
-  // Verify OTP Form
-  const verifyForm = useForm<MobileLoginVerifyData>({
-    resolver: zodResolver(mobileLoginVerifySchema),
-    defaultValues: {
-      phone: '',
-      otp: '',
-    },
-  });
-
-  const handleRequestOTP = async (data: MobileLoginRequestData) => {
-    setIsLoading(true);
-    try {
-      const res = await apiRequest('POST', '/api/auth/request-otp', { phone: `+91${data.phone}` });
-      const result = await res.json();
-
-      if (!res.ok) {
-        throw new Error(result.message || 'Failed to send OTP');
-      }
-
-      toast({
-        title: "OTP Sent!",
-        description: "Check your phone for the verification code",
-      });
-
-      setPhone(`+91${data.phone}`);
-      verifyForm.setValue('phone', `+91${data.phone}`);
-      verifyForm.setValue('otp', '');
-      setOtpDigits(['', '', '', '', '', '']);
-      setStep('verify');
-      setCountdown(60); // 60 seconds until resend
-      setCanResend(false);
-    } catch (error) {
-      toast({
-        title: "Error",
-        description: error instanceof Error ? error.message : "Failed to send OTP",
-        variant: "destructive",
-      });
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  const handleVerifyOTP = async (data: MobileLoginVerifyData) => {
-    setIsLoading(true);
-    try {
-      const res = await apiRequest('POST', '/api/auth/verify-otp', data);
-      const result = await res.json();
-
-      if (!res.ok) {
-        throw new Error(result.message || 'Failed to verify OTP');
-      }
-
-      // Update auth cache so the app recognises the session immediately
-      queryClient.setQueryData(["/api/user"], result);
-
-      toast({
-        title: "Success!",
-        description: "Login successful",
-      });
-
-      navigate('/');
-    } catch (error) {
-      toast({
-        title: "Error",
-        description: error instanceof Error ? error.message : "Failed to verify OTP",
-        variant: "destructive",
-      });
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  const handleResendOTP = async () => {
-    setIsLoading(true);
-    try {
-      const res = await apiRequest('POST', '/api/auth/request-otp', { phone });
-      const result = await res.json();
-
-      if (!res.ok) {
-        throw new Error(result.message || 'Failed to send OTP');
-      }
-
-      toast({
-        title: "OTP Resent!",
-        description: "Check your phone for the new verification code",
-      });
-
-      setCountdown(60);
-      setCanResend(false);
-    } catch (error) {
-      toast({
-        title: "Error",
-        description: error instanceof Error ? error.message : "Failed to resend OTP",
-        variant: "destructive",
-      });
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  if (step === 'request') {
-    return (
-      <Form {...requestForm}>
-        <form onSubmit={requestForm.handleSubmit(handleRequestOTP)} className="space-y-4 mt-4">
-          <div className="text-center mb-4">
-            <Phone className="mx-auto h-12 w-12 text-primary mb-2" />
-            <p className="text-sm text-muted-foreground">
-              Enter your registered phone number to receive an OTP
-            </p>
+        {/* Patient portal entry point */}
+        <div className="relative my-2">
+          <div className="absolute inset-0 flex items-center">
+            <span className="w-full border-t" />
           </div>
-
-          <FormField
-            control={requestForm.control}
-            name="phone"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Phone Number</FormLabel>
-                <FormControl>
-                  <div className="flex">
-                    <span className="flex items-center px-3 border border-r-0 rounded-l-md bg-muted text-sm text-muted-foreground select-none">+91</span>
-                    <Input
-                      type="text"
-                      inputMode="numeric"
-                      placeholder="Enter 10-digit number"
-                      className="rounded-l-none"
-                      maxLength={10}
-                      {...field}
-                      onChange={(e) => {
-                        const val = e.target.value.replace(/\D/g, '').slice(0, 10);
-                        field.onChange(val);
-                      }}
-                      disabled={isLoading}
-                    />
-                  </div>
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-
-          <Button type="submit" className="w-full" disabled={isLoading}>
-            {isLoading ? (
-              <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Sending OTP...
-              </>
-            ) : (
-              'Send OTP'
-            )}
-          </Button>
-
-          <div className="text-center">
-            <Button
-              type="button"
-              variant="link"
-              onClick={() => {
-                const tabsList = document.querySelector('[role="tablist"]');
-                const loginTab = tabsList?.querySelector('[value="login"]') as HTMLButtonElement;
-                loginTab?.click();
-              }}
-            >
-              Back to username login
-            </Button>
+          <div className="relative flex justify-center text-xs uppercase">
+            <span className="bg-card px-2 text-muted-foreground">or</span>
           </div>
-        </form>
-      </Form>
-    );
-  }
-
-  return (
-    <Form {...verifyForm}>
-      <form onSubmit={verifyForm.handleSubmit(handleVerifyOTP)} className="space-y-4 mt-4">
-        <div className="text-center mb-4">
-          <Lock className="mx-auto h-12 w-12 text-primary mb-2" />
-          <p className="text-sm text-muted-foreground">
-            Enter the 6-digit OTP sent to {phone}
-          </p>
         </div>
-
-        <FormField
-          control={verifyForm.control}
-          name="otp"
-          render={({ field, fieldState }) => (
-            <FormItem>
-              <FormLabel>Verification Code</FormLabel>
-              <FormControl>
-                <div className="flex gap-2 justify-center">
-                  {otpDigits.map((digit, idx) => (
-                    <input
-                      key={idx}
-                      ref={el => { otpRefs.current[idx] = el; }}
-                      type="text"
-                      inputMode="numeric"
-                      maxLength={1}
-                      autoComplete="off"
-                      value={digit}
-                      className="w-10 h-10 text-center border border-input rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                      onChange={e => {
-                        const val = e.target.value.replace(/\D/g, '').slice(-1);
-                        const next = [...otpDigits];
-                        next[idx] = val;
-                        setOtpDigits(next);
-                        field.onChange(next.join(''));
-                        if (val && idx < 5) otpRefs.current[idx + 1]?.focus();
-                      }}
-                      onKeyDown={e => {
-                        if (e.key === 'Backspace' && !otpDigits[idx] && idx > 0) {
-                          otpRefs.current[idx - 1]?.focus();
-                        }
-                      }}
-                      onPaste={e => {
-                        e.preventDefault();
-                        const pasted = e.clipboardData.getData('text').replace(/\D/g, '').slice(0, 6);
-                        const next = [...otpDigits];
-                        pasted.split('').forEach((ch, i) => { if (i < 6) next[i] = ch; });
-                        setOtpDigits(next);
-                        field.onChange(next.join(''));
-                        const focusIdx = Math.min(pasted.length, 5);
-                        otpRefs.current[focusIdx]?.focus();
-                      }}
-                    />
-                  ))}
-                </div>
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        {countdown > 0 && (
-          <Alert>
-            <AlertCircle className="h-4 w-4" />
-            <AlertDescription>
-              You can resend OTP in {countdown} seconds
-            </AlertDescription>
-          </Alert>
-        )}
-
-        <Button type="submit" className="w-full" disabled={isLoading}>
-          {isLoading ? (
-            <>
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              Verifying...
-            </>
-          ) : (
-            'Verify OTP'
-          )}
+        <Button asChild type="button" variant="outline" className="w-full border-primary text-primary hover:bg-primary/10">
+          <Link href="/patient-login">Patient Login</Link>
         </Button>
-
-        <div className="flex flex-col gap-2">
-          <Button
-            type="button"
-            variant="outline"
-            onClick={handleResendOTP}
-            disabled={!canResend || isLoading}
-            className="w-full"
-          >
-            Resend OTP
-          </Button>
-
-          <Button
-            type="button"
-            variant="link"
-            onClick={() => {
-              setStep('request');
-              requestForm.reset();
-              verifyForm.reset();
-              setOtpDigits(['', '', '', '', '', '']);
-            }}
-          >
-            Change phone number
-          </Button>
-        </div>
       </form>
     </Form>
   );

--- a/client/src/pages/auth/patient-forgot-mpin.tsx
+++ b/client/src/pages/auth/patient-forgot-mpin.tsx
@@ -1,4 +1,4 @@
-// Patient self-registration wizard: Mobile -> OTP -> Name -> MPIN -> Confirm MPIN (AUTH-002)
+// Self-service Forgot MPIN wizard: Mobile -> OTP -> New MPIN -> Confirm MPIN
 import { useState, useEffect } from "react";
 import { Link, useLocation } from "wouter";
 import { useForm } from "react-hook-form";
@@ -9,33 +9,32 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage, FormDescription } from "@/components/ui/form";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { ArrowLeft, Phone, Lock, User, AlertCircle, ChevronRight, ChevronLeft, Loader2 } from "lucide-react";
+import { ArrowLeft, Phone, Lock, AlertCircle, ChevronRight, ChevronLeft, Loader2 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { Progress } from "@/components/ui/progress";
 import { MpinKeypad } from "@/components/mpin-keypad";
 import { OtpInput } from "@/components/otp-input";
 
-const TOTAL_STEPS = 5;
+const TOTAL_STEPS = 4;
 
-const patientRegisterSchema = z
+const forgotMpinSchema = z
   .object({
     mobileNumber: z
       .string()
       .length(10, "Mobile number must be 10 digits")
       .regex(/^\d{10}$/, "Mobile number must contain only digits"),
     otp: z.string().length(6, "OTP must be 6 digits").regex(/^\d{6}$/, "OTP must contain only digits"),
-    name: z.string().min(2, "Name is required"),
-    mpin: z.string().length(4, "MPIN must be 4 digits").regex(/^\d{4}$/, "MPIN must contain only digits"),
+    newMpin: z.string().length(4, "MPIN must be 4 digits").regex(/^\d{4}$/, "MPIN must contain only digits"),
     confirmMpin: z.string().length(4, "MPIN must be 4 digits").regex(/^\d{4}$/, "MPIN must contain only digits"),
   })
-  .refine((data) => data.mpin === data.confirmMpin, {
+  .refine((data) => data.newMpin === data.confirmMpin, {
     message: "MPINs don't match",
     path: ["confirmMpin"],
   });
 
-type PatientRegisterData = z.infer<typeof patientRegisterSchema>;
+type ForgotMpinData = z.infer<typeof forgotMpinSchema>;
 
-// Parse a fetch Response into { ok, status, body } without throwing (apiRequest throws on non-2xx)
+// Parse a fetch Response into { ok, status, body } without throwing
 async function callApi(url: string, payload: unknown) {
   const res = await fetch(url, {
     method: "POST",
@@ -52,33 +51,22 @@ async function callApi(url: string, payload: unknown) {
   return { ok: res.ok, status: res.status, body };
 }
 
-export default function PatientRegister() {
+export default function PatientForgotMpin() {
   const [, navigate] = useLocation();
   const { toast } = useToast();
   const [isLoading, setIsLoading] = useState(false);
   const [currentStep, setCurrentStep] = useState(1);
   const [showMpin, setShowMpin] = useState(false);
-
-  // Step 1/4: already-registered block shown inline with a "Go to Login" action
-  const [alreadyRegistered, setAlreadyRegistered] = useState(false);
-
-  // Step 2: OTP digit boxes + resend countdown
+  const [notRegistered, setNotRegistered] = useState(false);
   const [otpDigits, setOtpDigits] = useState(["", "", "", "", "", ""]);
   const [countdown, setCountdown] = useState(0);
   const [otpError, setOtpError] = useState("");
 
-  const form = useForm<PatientRegisterData>({
-    resolver: zodResolver(patientRegisterSchema),
-    defaultValues: {
-      mobileNumber: "",
-      otp: "",
-      name: "",
-      mpin: "",
-      confirmMpin: "",
-    },
+  const form = useForm<ForgotMpinData>({
+    resolver: zodResolver(forgotMpinSchema),
+    defaultValues: { mobileNumber: "", otp: "", newMpin: "", confirmMpin: "" },
   });
 
-  // Resend countdown timer (mirrors MobileLoginForm)
   useEffect(() => {
     if (countdown > 0) {
       const timer = setTimeout(() => setCountdown(countdown - 1), 1000);
@@ -92,28 +80,23 @@ export default function PatientRegister() {
     setOtpError("");
   };
 
-  // --- Step 1: request OTP for the entered mobile ---
+  // --- Step 1: request OTP for the registered mobile ---
   const handleRequestOtp = async () => {
-    const valid = await form.trigger("mobileNumber");
-    if (!valid) return;
+    if (!(await form.trigger("mobileNumber"))) return;
 
     setIsLoading(true);
-    setAlreadyRegistered(false);
+    setNotRegistered(false);
     try {
-      const { ok, status, body } = await callApi("/api/register/request-otp", {
+      const { ok, status, body } = await callApi("/api/auth/patient/forgot-mpin/request-otp", {
         phone: form.getValues("mobileNumber"),
       });
 
       if (!ok) {
-        if (status === 400 && (body.code === "ALREADY_REGISTERED" || /already registered/i.test(body.message || ""))) {
-          setAlreadyRegistered(true);
+        if (status === 404 && (body.code === "NOT_REGISTERED" || /not registered/i.test(body.message || ""))) {
+          setNotRegistered(true);
           return;
         }
-        toast({
-          title: "Could not send OTP",
-          description: body.message || "Please try again",
-          variant: "destructive",
-        });
+        toast({ title: "Could not send OTP", description: body.message || "Please try again", variant: "destructive" });
         return;
       }
 
@@ -132,11 +115,10 @@ export default function PatientRegister() {
   const handleResendOtp = async () => {
     setIsLoading(true);
     try {
-      const { ok, status, body } = await callApi("/api/register/request-otp", {
+      const { ok, status, body } = await callApi("/api/auth/patient/forgot-mpin/request-otp", {
         phone: form.getValues("mobileNumber"),
       });
       if (!ok) {
-        // Server-side cooldown hit — re-arm the client countdown so the button backs off too
         if (status === 429) setCountdown(60);
         toast({ title: "Could not resend OTP", description: body.message || "Please try again", variant: "destructive" });
         return;
@@ -153,8 +135,7 @@ export default function PatientRegister() {
 
   // --- Step 2: verify OTP, binding the phone to the session ---
   const handleVerifyOtp = async () => {
-    const valid = await form.trigger("otp");
-    if (!valid) {
+    if (!(await form.trigger("otp"))) {
       setOtpError("OTP must be 6 digits");
       return;
     }
@@ -162,7 +143,7 @@ export default function PatientRegister() {
     setIsLoading(true);
     setOtpError("");
     try {
-      const { ok, status, body } = await callApi("/api/register/verify-phone", {
+      const { ok, status, body } = await callApi("/api/auth/patient/forgot-mpin/verify-otp", {
         phone: form.getValues("mobileNumber"),
         otp: form.getValues("otp"),
       });
@@ -187,17 +168,15 @@ export default function PatientRegister() {
     }
   };
 
-  // --- Step 5: create the account ---
-  const handleFinalSubmit = async () => {
-    const valid = await form.trigger("confirmMpin");
-    if (!valid) return;
+  // --- Step 4: reset the MPIN ---
+  const handleReset = async () => {
+    if (!(await form.trigger("confirmMpin"))) return;
 
     setIsLoading(true);
     try {
-      const { ok, status, body } = await callApi("/api/auth/patient/register", {
-        name: form.getValues("name"),
+      const { ok, status, body } = await callApi("/api/auth/patient/forgot-mpin/reset", {
         mobileNumber: form.getValues("mobileNumber"),
-        mpin: form.getValues("mpin"),
+        newMpin: form.getValues("newMpin"),
       });
 
       if (!ok) {
@@ -207,25 +186,20 @@ export default function PatientRegister() {
             description: "Verification expired — please verify your number again",
             variant: "destructive",
           });
-          // Reset wizard back to mobile entry (AUTH-002 Part 5)
           setOtpValue(["", "", "", "", "", ""]);
-          form.setValue("mpin", "");
+          form.setValue("newMpin", "");
           form.setValue("confirmMpin", "");
           setCountdown(0);
           setCurrentStep(1);
           return;
         }
-        toast({
-          title: "Registration Failed",
-          description: body.message || "Failed to create account",
-          variant: "destructive",
-        });
+        toast({ title: "Reset Failed", description: body.message || "Failed to reset MPIN", variant: "destructive" });
         return;
       }
 
       toast({
-        title: "Registration Successful!",
-        description: "Your account has been created. Redirecting to login...",
+        title: "MPIN Reset Successful!",
+        description: "You can now login with your new MPIN. Redirecting to login...",
       });
       setTimeout(() => navigate("/patient-login"), 2000);
     } catch {
@@ -235,39 +209,21 @@ export default function PatientRegister() {
     }
   };
 
-  // MPIN keypad handlers (kept from the original 3-step wizard)
-  const handleMpinInput = (field: "mpin" | "confirmMpin", digit: string) => {
+  // MPIN keypad handlers
+  const handleMpinInput = (field: "newMpin" | "confirmMpin", digit: string) => {
     const currentValue = form.getValues(field);
     if (currentValue.length < 4) form.setValue(field, currentValue + digit);
   };
-  const handleMpinClear = (field: "mpin" | "confirmMpin") => form.setValue(field, "");
-  const handleMpinBackspace = (field: "mpin" | "confirmMpin") =>
+  const handleMpinClear = (field: "newMpin" | "confirmMpin") => form.setValue(field, "");
+  const handleMpinBackspace = (field: "newMpin" | "confirmMpin") =>
     form.setValue(field, form.getValues(field).slice(0, -1));
 
-  // Step 4 -> 5 (validate the new MPIN before confirming)
-  const goToConfirmMpin = async () => {
-    const valid = await form.trigger("mpin");
-    if (valid) setCurrentStep(5);
-  };
-
   const stepTitles: Record<number, { title: string; description: string }> = {
-    1: { title: "Mobile Number", description: "Enter your 10-digit mobile number to get started" },
+    1: { title: "Forgot MPIN", description: "Enter your registered mobile number to receive an OTP" },
     2: { title: "Verify OTP", description: "Enter the 6-digit code sent to your mobile" },
-    3: { title: "Your Name", description: "Tell us your full name" },
-    4: { title: "Create MPIN", description: "Choose a 4-digit PIN you'll remember" },
-    5: { title: "Confirm MPIN", description: "Re-enter your MPIN to confirm" },
+    3: { title: "New MPIN", description: "Choose a new 4-digit PIN you'll remember" },
+    4: { title: "Confirm MPIN", description: "Re-enter your new MPIN to confirm" },
   };
-
-  const lockedMobile = (
-    <FormItem>
-      <FormLabel>Mobile Number</FormLabel>
-      <div className="relative">
-        <Phone className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-500" />
-        <Input value={form.getValues("mobileNumber")} readOnly disabled className="pl-10 bg-muted" />
-      </div>
-      <FormDescription>Verified — this will be your login ID</FormDescription>
-    </FormItem>
-  );
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center p-4">
@@ -280,15 +236,12 @@ export default function PatientRegister() {
             </Button>
           </Link>
 
-          {/* Progress indicator */}
           <Progress value={(currentStep / TOTAL_STEPS) * 100} className="mb-4" />
 
           <div className="flex items-center justify-center mb-4">
             <div className="w-16 h-16 bg-blue-500 rounded-full flex items-center justify-center">
               {currentStep === 1 && <Phone className="w-8 h-8 text-white" />}
-              {currentStep === 2 && <Lock className="w-8 h-8 text-white" />}
-              {currentStep === 3 && <User className="w-8 h-8 text-white" />}
-              {(currentStep === 4 || currentStep === 5) && <Lock className="w-8 h-8 text-white" />}
+              {currentStep >= 2 && <Lock className="w-8 h-8 text-white" />}
             </div>
           </div>
           <CardTitle className="text-2xl text-center">{stepTitles[currentStep].title}</CardTitle>
@@ -319,29 +272,23 @@ export default function PatientRegister() {
                               autoFocus
                               onChange={(e) => {
                                 field.onChange(e.target.value.replace(/\D/g, "").slice(0, 10));
-                                setAlreadyRegistered(false);
+                                setNotRegistered(false);
                               }}
                             />
                           </div>
                         </FormControl>
-                        <FormDescription>This will be your login ID</FormDescription>
                         <FormMessage />
                       </FormItem>
                     )}
                   />
 
-                  {alreadyRegistered && (
+                  {notRegistered && (
                     <Alert variant="destructive">
                       <AlertCircle className="h-4 w-4" />
                       <AlertDescription className="space-y-2">
-                        <p>This mobile number is already registered. Please login using your MPIN.</p>
-                        <Button
-                          type="button"
-                          size="sm"
-                          variant="outline"
-                          onClick={() => navigate("/patient-login")}
-                        >
-                          Go to Login
+                        <p>This mobile number is not registered. Please register first.</p>
+                        <Button type="button" size="sm" variant="outline" onClick={() => navigate("/patient-register")}>
+                          Go to Register
                         </Button>
                       </AlertDescription>
                     </Alert>
@@ -360,15 +307,6 @@ export default function PatientRegister() {
                       </>
                     )}
                   </Button>
-
-                  <div className="text-center text-sm mt-4">
-                    <span className="text-gray-600">Already have an account? </span>
-                    <Link href="/patient-login">
-                      <Button variant="link" className="p-0 h-auto font-semibold">
-                        Login here
-                      </Button>
-                    </Link>
-                  </div>
                 </>
               )}
 
@@ -431,28 +369,35 @@ export default function PatientRegister() {
                 </>
               )}
 
-              {/* Step 3: Full name (mobile locked) */}
+              {/* Step 3: New MPIN */}
               {currentStep === 3 && (
                 <>
-                  {lockedMobile}
+                  <FormItem>
+                    <FormLabel>Mobile Number</FormLabel>
+                    <div className="relative">
+                      <Phone className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-500" />
+                      <Input value={form.getValues("mobileNumber")} readOnly disabled className="pl-10 bg-muted" />
+                    </div>
+                    <FormDescription>Verified</FormDescription>
+                  </FormItem>
 
                   <FormField
                     control={form.control}
-                    name="name"
+                    name="newMpin"
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel>Full Name</FormLabel>
+                        <FormLabel>New 4-Digit MPIN</FormLabel>
                         <FormControl>
-                          <div className="relative">
-                            <User className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-500" />
-                            <Input
-                              {...field}
-                              type="text"
-                              placeholder="Enter your full name"
-                              className="pl-10"
-                              autoFocus
-                            />
-                          </div>
+                          <MpinKeypad
+                            value={field.value}
+                            placeholder="Enter 4 digits"
+                            showToggle
+                            reveal={showMpin}
+                            onToggleReveal={() => setShowMpin(!showMpin)}
+                            onDigit={(d) => handleMpinInput("newMpin", d)}
+                            onClear={() => handleMpinClear("newMpin")}
+                            onBackspace={() => handleMpinBackspace("newMpin")}
+                          />
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -463,8 +408,9 @@ export default function PatientRegister() {
                     type="button"
                     className="w-full"
                     onClick={async () => {
-                      if (await form.trigger("name")) setCurrentStep(4);
+                      if (await form.trigger("newMpin")) setCurrentStep(4);
                     }}
+                    disabled={form.watch("newMpin").length !== 4}
                   >
                     Next
                     <ChevronRight className="w-4 h-4 ml-2" />
@@ -472,61 +418,15 @@ export default function PatientRegister() {
                 </>
               )}
 
-              {/* Step 4: Create MPIN */}
+              {/* Step 4: Confirm new MPIN */}
               {currentStep === 4 && (
-                <>
-                  {lockedMobile}
-
-                  <FormField
-                    control={form.control}
-                    name="mpin"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Create Your 4-Digit MPIN</FormLabel>
-                        <FormControl>
-                          <MpinKeypad
-                            value={field.value}
-                            placeholder="Enter 4 digits"
-                            showToggle
-                            reveal={showMpin}
-                            onToggleReveal={() => setShowMpin(!showMpin)}
-                            onDigit={(d) => handleMpinInput("mpin", d)}
-                            onClear={() => handleMpinClear("mpin")}
-                            onBackspace={() => handleMpinBackspace("mpin")}
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-
-                  <div className="flex gap-2">
-                    <Button type="button" variant="outline" className="flex-1" onClick={() => setCurrentStep(3)}>
-                      <ChevronLeft className="w-4 h-4 mr-2" />
-                      Back
-                    </Button>
-                    <Button
-                      type="button"
-                      className="flex-1"
-                      onClick={goToConfirmMpin}
-                      disabled={form.watch("mpin").length !== 4}
-                    >
-                      Next
-                      <ChevronRight className="w-4 h-4 ml-2" />
-                    </Button>
-                  </div>
-                </>
-              )}
-
-              {/* Step 5: Confirm MPIN */}
-              {currentStep === 5 && (
                 <>
                   <FormField
                     control={form.control}
                     name="confirmMpin"
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel>Confirm Your MPIN</FormLabel>
+                        <FormLabel>Confirm Your New MPIN</FormLabel>
                         <FormControl>
                           <MpinKeypad
                             value={field.value}
@@ -543,23 +443,21 @@ export default function PatientRegister() {
 
                   <Alert>
                     <AlertCircle className="h-4 w-4" />
-                    <AlertDescription>
-                      Remember your MPIN! You'll need it to login to your account.
-                    </AlertDescription>
+                    <AlertDescription>Remember your new MPIN! You'll need it to login.</AlertDescription>
                   </Alert>
 
                   <div className="flex gap-2">
-                    <Button type="button" variant="outline" className="flex-1" onClick={() => setCurrentStep(4)}>
+                    <Button type="button" variant="outline" className="flex-1" onClick={() => setCurrentStep(3)}>
                       <ChevronLeft className="w-4 h-4 mr-2" />
                       Back
                     </Button>
                     <Button
                       type="button"
                       className="flex-1"
-                      onClick={handleFinalSubmit}
+                      onClick={handleReset}
                       disabled={isLoading || form.watch("confirmMpin").length !== 4}
                     >
-                      {isLoading ? "Creating..." : "Create Account"}
+                      {isLoading ? "Resetting..." : "Reset MPIN"}
                     </Button>
                   </div>
                 </>

--- a/client/src/pages/auth/patient-login.tsx
+++ b/client/src/pages/auth/patient-login.tsx
@@ -7,8 +7,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
-import { Alert, AlertDescription } from "@/components/ui/alert";
-import { ArrowLeft, Phone, Lock, AlertCircle } from "lucide-react";
+import { ArrowLeft, Phone, Lock } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 
@@ -235,12 +234,13 @@ export default function PatientLogin() {
                 )}
               />
 
-              <Alert>
-                <AlertCircle className="h-4 w-4" />
-                <AlertDescription>
-                  If you've forgotten your MPIN, please contact your clinic administrator for assistance.
-                </AlertDescription>
-              </Alert>
+              <div className="text-right">
+                <Link href="/patient-forgot-mpin">
+                  <Button variant="link" className="p-0 h-auto text-sm">
+                    Forgot MPIN?
+                  </Button>
+                </Link>
+              </div>
 
               <Button type="submit" className="w-full" disabled={isLoading}>
                 {isLoading ? "Logging in..." : "Login"}

--- a/client/src/pages/home-page.tsx
+++ b/client/src/pages/home-page.tsx
@@ -18,7 +18,12 @@ export default function HomePage() {
   const { user, isLoading: isAuthLoading } = useAuth();
 
   const { data: doctors, isLoading } = useQuery<User[]>({
-    queryKey: [specialty ? `/api/doctors/${specialty}` : "/api/doctors"],
+    // Specialty is a query param on /api/doctors — "all" (or empty) means no filter
+    queryKey: [
+      specialty && specialty !== "all"
+        ? `/api/doctors?specialty=${encodeURIComponent(specialty)}`
+        : "/api/doctors",
+    ],
   });
 
   const filteredDoctors = doctors?.filter(doctor =>

--- a/client/src/pages/landing-page.tsx
+++ b/client/src/pages/landing-page.tsx
@@ -46,11 +46,11 @@ export default function LandingPage() {
 
 
             {/* Quick auth entry points */}
-            <div className="mt-4 flex flex-wrap gap-2 text-sm">
-              <Button asChild variant="ghost" className="px-3">
+            <div className="mt-4 flex flex-wrap gap-3">
+              <Button asChild size="lg" className="rounded-full">
                 <Link href="/patient-login">Patient Login</Link>
               </Button>
-              <Button asChild variant="link" className="px-3">
+              <Button asChild size="lg" variant="outline" className="rounded-full border-primary text-primary hover:bg-primary/10">
                 <Link href="/patient-register">Create Patient Account</Link>
               </Button>
             </div>

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -14,6 +14,15 @@ declare global {
   }
 }
 
+declare module "express-session" {
+  interface SessionData {
+    registrationPhone?: string;        // OTP-verified phone for pending registration
+    registrationVerifiedAt?: number;   // epoch ms, valid for 15 minutes
+    resetMpinPhone?: string;           // OTP-verified phone for pending MPIN reset
+    resetMpinVerifiedAt?: number;      // epoch ms, valid for 15 minutes
+  }
+}
+
 const scryptAsync = promisify(scrypt);
 
 async function hashPassword(password: string) {
@@ -348,7 +357,10 @@ export function setupAuth(app: Express) {
       // Check if user already exists
       const existingUser = await storage.getUserByPhone(phone);
       if (existingUser) {
-        return res.status(400).json({ message: "An account already exists with this phone number" });
+        return res.status(400).json({
+          message: "This mobile number is already registered. Please login using your MPIN.",
+          code: "ALREADY_REGISTERED",
+        });
       }
 
       // Check rate limiting
@@ -380,6 +392,43 @@ export function setupAuth(app: Express) {
     } catch (error) {
       console.error("Error sending registration OTP:", error);
       res.status(500).json({ message: "Failed to send OTP" });
+    }
+  });
+
+  // Verify registration OTP only — binds the verified phone to the session (AUTH-002)
+  app.post("/api/register/verify-phone", async (req, res) => {
+    try {
+      let { phone, otp } = req.body;
+      if (!phone || !otp) {
+        return res.status(400).json({ message: "Phone number and OTP are required" });
+      }
+      phone = phone.replace(/\D/g, "");
+      if (phone.length > 10) phone = phone.slice(-10);
+
+      const otpRecord = await storage.getValidOtp(phone, otp);
+      if (!otpRecord) {
+        return res.status(401).json({ message: "Invalid or expired OTP" });
+      }
+      if ((otpRecord.verificationAttempts ?? 0) >= 5) {
+        return res.status(429).json({ message: "Too many attempts. Please request a new OTP" });
+      }
+      await storage.incrementOtpAttempts(otpRecord.id);
+      await storage.markOtpAsVerified(otpRecord.id);
+
+      req.session.registrationPhone = phone;
+      req.session.registrationVerifiedAt = Date.now();
+
+      // Persist the session before responding so the register step can rely on it
+      req.session.save((err) => {
+        if (err) {
+          console.error("Failed to persist registration session:", err);
+          return res.status(500).json({ message: "Failed to verify OTP" });
+        }
+        res.json({ verified: true, phone });
+      });
+    } catch (error) {
+      console.error("Registration phone verification error:", error);
+      res.status(500).json({ message: "Failed to verify OTP" });
     }
   });
 
@@ -689,16 +738,11 @@ export function setupAuth(app: Express) {
   // Patient Self-Registration with MPIN
   app.post("/api/auth/patient/register", async (req, res) => {
     try {
-      const { name, username, mobileNumber, mpin } = req.body;
+      const { name, mobileNumber, mpin } = req.body;
 
       // Validate input
-      if (!name || !username || !mobileNumber || !mpin) {
-        return res.status(400).json({ message: "Name, username, mobile number, and MPIN are required" });
-      }
-
-      // Validate username format
-      if (!/^[a-zA-Z0-9_]{3,20}$/.test(username)) {
-        return res.status(400).json({ message: "Username must be 3-20 characters and contain only letters, numbers, and underscores" });
+      if (!name || !mobileNumber || !mpin) {
+        return res.status(400).json({ message: "Name, mobile number, and MPIN are required" });
       }
 
       // Validate mobile number format
@@ -711,18 +755,31 @@ export function setupAuth(app: Express) {
         return res.status(400).json({ message: "MPIN must be exactly 4 digits" });
       }
 
-      // Check if username already exists
-      const existingUsername = await storage.getUserByUsername(username);
-      if (existingUsername) {
-        return res.status(400).json({ message: "Username already taken. Please choose another one." });
+      // AUTH-002: phone must have been OTP-verified in this session within 15 minutes
+      const verifiedPhone = req.session.registrationPhone;
+      const verifiedAt = req.session.registrationVerifiedAt ?? 0;
+      const VERIFICATION_WINDOW_MS = 15 * 60 * 1000;
+      if (verifiedPhone !== mobileNumber || Date.now() - verifiedAt > VERIFICATION_WINDOW_MS) {
+        return res.status(403).json({
+          message: "Mobile number not verified. Please complete OTP verification first.",
+        });
       }
 
       // Check if mobile number already exists
       const existingUser = await storage.getUserByPhone(mobileNumber);
       if (existingUser) {
-        return res.status(400).json({ message: "Mobile number already registered" });
+        return res.status(400).json({
+          message: "This mobile number is already registered. Please login using your MPIN.",
+          code: "ALREADY_REGISTERED",
+        });
       }
-      
+
+      // Auto-generate a username (collision-safe) — patients never see it
+      let username = `patient${mobileNumber.slice(-6)}`;
+      if (await storage.getUserByUsername(username)) {
+        username = `patient${mobileNumber.slice(-6)}${randomBytes(2).toString("hex")}`;
+      }
+
       // Hash MPIN (using same function as password)
       const hashedMpin = await hashMpin(mpin);
       
@@ -746,9 +803,13 @@ export function setupAuth(app: Express) {
       // Set MPIN for the user
       await storage.updateMpin(user.id, hashedMpin);
 
-      res.status(201).json({ 
+      // AUTH-002: clear the verification so it cannot be reused
+      delete req.session.registrationPhone;
+      delete req.session.registrationVerifiedAt;
+
+      res.status(201).json({
         message: "Registration successful! You can now login with your mobile number and MPIN.",
-        userId: user.id 
+        userId: user.id
       });
     } catch (error) {
       console.error("Patient registration error:", error);
@@ -877,6 +938,137 @@ export function setupAuth(app: Express) {
     } catch (error) {
       console.error("Change MPIN error:", error);
       res.status(500).json({ message: "Failed to change MPIN" });
+    }
+  });
+
+  // ========== SELF-SERVICE FORGOT MPIN (OTP-verified) ==========
+
+  // Step 1: send an OTP to a registered patient's mobile
+  app.post("/api/auth/patient/forgot-mpin/request-otp", async (req, res) => {
+    try {
+      let { phone } = req.body;
+      if (!phone) {
+        return res.status(400).json({ message: "Phone number is required" });
+      }
+      phone = phone.replace(/\D/g, "");
+      if (phone.length > 10) phone = phone.slice(-10);
+
+      // Unlike registration, the number MUST belong to an existing patient
+      const user = await storage.getUserByPhoneForMpin(phone);
+      if (!user) {
+        return res.status(404).json({
+          message: "This mobile number is not registered. Please register first.",
+          code: "NOT_REGISTERED",
+        });
+      }
+
+      const canSend = await storage.canSendOtp(phone);
+      if (!canSend) {
+        return res.status(429).json({ message: process.env.NODE_ENV === 'production' ? "Please wait 1 minute before requesting another OTP" : "Please wait 10 seconds before requesting another OTP" });
+      }
+
+      await storage.cleanupExpiredOtps();
+
+      const otp = smsService.generateOTP();
+      const expiresAt = new Date(Date.now() + 10 * 60 * 1000); // 10 minutes
+      await storage.createOtpVerification({
+        phone,
+        otpCode: otp,
+        expiresAt,
+        verified: false,
+        verificationAttempts: 0
+      });
+      await storage.updateLastOtpSentAt(phone);
+      await smsService.sendOTP(phone, otp);
+
+      res.json({ message: "OTP sent successfully" });
+    } catch (error) {
+      console.error("Forgot MPIN OTP request error:", error);
+      res.status(500).json({ message: "Failed to send OTP" });
+    }
+  });
+
+  // Step 2: verify the OTP and bind the phone to the session for the reset step
+  app.post("/api/auth/patient/forgot-mpin/verify-otp", async (req, res) => {
+    try {
+      let { phone, otp } = req.body;
+      if (!phone || !otp) {
+        return res.status(400).json({ message: "Phone number and OTP are required" });
+      }
+      phone = phone.replace(/\D/g, "");
+      if (phone.length > 10) phone = phone.slice(-10);
+
+      const otpRecord = await storage.getValidOtp(phone, otp);
+      if (!otpRecord) {
+        return res.status(401).json({ message: "Invalid or expired OTP" });
+      }
+      if ((otpRecord.verificationAttempts ?? 0) >= 5) {
+        return res.status(429).json({ message: "Too many attempts. Please request a new OTP" });
+      }
+      await storage.incrementOtpAttempts(otpRecord.id);
+      await storage.markOtpAsVerified(otpRecord.id);
+
+      req.session.resetMpinPhone = phone;
+      req.session.resetMpinVerifiedAt = Date.now();
+
+      // Persist the session before responding so the reset step can rely on it
+      req.session.save((err) => {
+        if (err) {
+          console.error("Failed to persist MPIN reset session:", err);
+          return res.status(500).json({ message: "Failed to verify OTP" });
+        }
+        res.json({ verified: true, phone });
+      });
+    } catch (error) {
+      console.error("Forgot MPIN OTP verification error:", error);
+      res.status(500).json({ message: "Failed to verify OTP" });
+    }
+  });
+
+  // Step 3: set the new MPIN — only for the session-verified phone, within 15 minutes
+  app.post("/api/auth/patient/forgot-mpin/reset", async (req, res) => {
+    try {
+      const { mobileNumber, newMpin } = req.body;
+      if (!mobileNumber || !newMpin) {
+        return res.status(400).json({ message: "Mobile number and new MPIN are required" });
+      }
+      if (!/^\d{10}$/.test(mobileNumber)) {
+        return res.status(400).json({ message: "Mobile number must be 10 digits" });
+      }
+      if (!/^\d{4}$/.test(newMpin)) {
+        return res.status(400).json({ message: "MPIN must be exactly 4 digits" });
+      }
+
+      // Phone must have been OTP-verified in this session within 15 minutes
+      const verifiedPhone = req.session.resetMpinPhone;
+      const verifiedAt = req.session.resetMpinVerifiedAt ?? 0;
+      const VERIFICATION_WINDOW_MS = 15 * 60 * 1000;
+      if (verifiedPhone !== mobileNumber || Date.now() - verifiedAt > VERIFICATION_WINDOW_MS) {
+        return res.status(403).json({
+          message: "Mobile number not verified. Please complete OTP verification first.",
+        });
+      }
+
+      const user = await storage.getUserByPhoneForMpin(mobileNumber);
+      if (!user) {
+        return res.status(404).json({
+          message: "This mobile number is not registered. Please register first.",
+          code: "NOT_REGISTERED",
+        });
+      }
+
+      // updateMpin also resets attempt counters and clears any lockout
+      const hashedMpin = await hashMpin(newMpin);
+      await storage.updateMpin(user.id, hashedMpin);
+
+      // One reset per verification
+      delete req.session.resetMpinPhone;
+      delete req.session.resetMpinVerifiedAt;
+
+      res.json({ message: "MPIN reset successfully. You can now login with your new MPIN." });
+    } catch (error) {
+      console.error("Forgot MPIN reset error:", error);
+      res.status(500).json({ message: "Failed to reset MPIN" });
     }
   });
 }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -80,6 +80,17 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  // Distinct specialties of existing doctors (for the search filter dropdown)
+  app.get("/api/specialties", async (_req, res) => {
+    try {
+      const specialties = await storage.getDoctorSpecialties();
+      res.json(specialties);
+    } catch (error) {
+      console.error('Error fetching specialties:', error);
+      res.status(500).json({ message: 'Failed to fetch specialties' });
+    }
+  });
+
   // Get nearby clinics within specified radius (0-10km)
   app.get("/api/clinics/nearby", async (req, res) => {
     const { lat, lng, radius } = req.query;
@@ -301,7 +312,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   app.get("/api/doctors/:id", async (req, res) => {
     try {
-      const doctor = await storage.getDoctorWithClinic(parseInt(req.params.id));
+      const doctorId = parseInt(req.params.id);
+      if (isNaN(doctorId)) {
+        return res.status(400).json({ message: 'Invalid doctor id' });
+      }
+      const doctor = await storage.getDoctorWithClinic(doctorId);
       if (!doctor || doctor.role !== 'doctor') {
         return res.status(404).json({ message: 'Doctor not found' });
       }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -121,6 +121,7 @@ export interface IStorage {
   updateLastOtpSentAt(phone: string): Promise<void>;
   getDoctors(): Promise<User[]>;
   getDoctorsBySpecialty(specialty: string): Promise<User[]>;
+  getDoctorSpecialties(): Promise<string[]>;
   getDoctorWithClinic(id: number): Promise<(User & { clinic?: Clinic }) | undefined>;
   getDoctorsNearLocation(lat: number, lng: number, radiusInMiles?: number): Promise<User[]>;
   getClinicsNearLocation(lat: number, lng: number, radiusInKm?: number): Promise<(Clinic & { distance: number })[]>;
@@ -513,6 +514,18 @@ export class DatabaseStorage implements IStorage {
 
   async getDoctorsBySpecialty(specialty: string): Promise<User[]> {
     return await db.select().from(users).where(eq(users.specialty, specialty));
+  }
+
+  // Distinct specialties of existing doctors — drives the search filter dropdown
+  async getDoctorSpecialties(): Promise<string[]> {
+    const rows = await db
+      .selectDistinct({ specialty: users.specialty })
+      .from(users)
+      .where(eq(users.role, "doctor"));
+    return rows
+      .map((r) => r.specialty)
+      .filter((s): s is string => !!s)
+      .sort();
   }
 
   async getClinicAdmins(): Promise<(User & { clinic?: Clinic })[]> {


### PR DESCRIPTION
# AUTH-002 — OTP-Verified Patient Registration & MPIN Self-Service

Implements the user story in `docs/stories/AUTH-002-otp-verified-mpin-registration.md`.

## What's included

### 1. OTP-verified patient registration (AUTH-002)
- `/patient-register` is now a 5-step wizard: **Mobile → SMS OTP → Name → MPIN → Confirm MPIN**
- New `POST /api/register/verify-phone` endpoint binds the OTP-verified phone to the server session
- `POST /api/auth/patient/register` now **requires a session-verified phone (403 otherwise)** — closes the hole where anyone could register any mobile number unverified
- Username field removed — auto-generated server-side (`patient<last6>`), patients log in with mobile + MPIN
- Already-registered numbers get a clear error + "Go to Login" action
- Register tab removed from `/auth` (now staff/admin username+password only, with a Patient Login pointer); dead Firebase mobile-login code deleted

### 2. Self-service Forgot MPIN
- New `/patient-forgot-mpin` wizard: Mobile → OTP → New MPIN → Confirm
- 3 new endpoints (`forgot-mpin/request-otp`, `verify-otp`, `reset`) with the same 15-minute session-verification guard
- Resetting the MPIN also clears any lockout — locked-out patients can self-recover
- "Contact your clinic administrator" message replaced with a **Forgot MPIN?** link

### 3. UI entry points
- Landing hero: prominent **Patient Login** / **Create Patient Account** buttons
- Nav header: solid **Login** + new **Patient Register** button (dead `/auth` Register link removed)

### 4. Bug fix: specialty filter returned 500 / no results for every category
- Client sent specialty as a path (`/api/doctors/Dermatologist`) hitting the `:id` route → `parseInt` → NaN → Postgres 500; now sent as `?specialty=` query param
- Dropdown options were a stale hardcoded list that never matched DB values; new `GET /api/specialties` returns distinct specialties of real doctors
- `/api/doctors/:id` now returns 400 on non-numeric ids instead of a 500

### 5. Chore
- Capacitor `server.url` → `https://clinik.co.in` so the Android APK shell loads the live site

## Testing
- Full backend flow verified via curl (mock SMS): register without OTP → 403, wrong OTP → 401, happy path → 201 + MPIN login 200, already-registered → 400, session reuse → 403
- Forgot MPIN flow verified end-to-end: reset without OTP → 403, unregistered → 404, reset → login with new MPIN 200, second reset on consumed session → 403
- Specialty filter verified: `/api/doctors?specialty=Dermatology` returns the 3 dermatologists; old bad URL now 400
- Implementation reviewed by multi-agent adversarial review (14 findings; all must-fix items resolved)
- New shared components: `MpinKeypad`, `OtpInput`; Postman collection updated for all new endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Patient self-registration with phone verification and security code setup
  * Account recovery option for forgotten security codes
  * Real-time doctor specialty filtering in search
  * Dedicated patient login entry point with recovery link

* **Improvements**
  * Doctor specialties updated dynamically based on available data
  * Enhanced patient authentication navigation and workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->