### PR TITLE
feat: make patient mobile+MPIN login primary on /auth, staff login secondary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,56 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+ClinicFlow is a clinic appointment + token-queue management system: an Express/PostgreSQL backend and a React (Vite) SPA, also packaged as an Android app via Capacitor.
+
+## Commands
+
+```bash
+npm run dev          # Dev server: Express + Vite middleware, HMR. tsx server/index.ts
+npm run check        # TypeScript typecheck (tsc). There is NO test runner — see note below.
+npm run build        # vite build (client → dist/public) + esbuild bundle (server → dist/index.js)
+npm start            # Run production build (NODE_ENV=production node dist/index.js)
+npm run build:android # vite build --mode capacitor + cap sync + cap build android
+
+# Database (Drizzle, schema is shared/schema.ts)
+npm run db:push      # Push schema to DB (dev) — no migration file
+npm run db:generate  # Generate a SQL migration from schema changes
+npm run db:migrate   # Apply migrations via tsx migrations/run.ts (used for prod)
+
+# Seed / admin scripts (each is `tsx <file>`)
+npm run create-super-admin | create-clinic-admin | create-test-doctor | create-test-patient
+npm run seed-data | seed-policies | assign-doctor-to-attender | reset-password
+```
+
+There are **no automated tests** and no lint script. `npm run check` only runs `tsc`. Verification is manual: run the app and smoke-test via `curl` (per rule #9 below). Do not invent a test command.
+
+Server listens on **port 5001** by default (`PORT` env overrides), auto-incrementing to the next free port if taken — see `findAvailablePort` in `server/index.ts`. (The README's "3000" is stale.)
+
+## Architecture
+
+**Stack:** React 18 + Wouter (routing) + TanStack Query + Tailwind/ShadCN on the client; Express + Passport (session auth) + Drizzle ORM + PostgreSQL on the server. Path aliases: `@/` → `client/src`, `@shared` → `shared`.
+
+**Three layers, one shared schema:**
+- `shared/schema.ts` — the single source of truth. Drizzle table defs + relations + `drizzle-zod` insert schemas + inferred TS types, all imported by both client and server. Add columns here first, then `db:generate`.
+- `server/routes.ts` — **one ~4000-line file** registering every `/api/*` route. Pattern: validate (Zod) → call `storage` → return JSON.
+- `server/storage.ts` — **one ~5300-line `storage` singleton** that is the entire DB-access layer. Almost all business logic and queries live here, not in services. This and `routes.ts` both far exceed the 600-line rule below; that rule describes the target, not the current reality. Don't refactor them unprompted, but don't grow them carelessly either.
+- `server/services/` — narrower domain logic: `eta.ts` (queue ETA), `wallet.ts` (wallet/refunds), `notification.ts`, `sms.ts` (Twilio OTP).
+
+**Auth is multi-modal** (`server/auth.ts`): passport-local username/password, **MPIN** (scrypt-hashed, with attempt lockout) for patients, **OTP-over-SMS** (Twilio) for phone-verified registration and forgot-MPIN, plus Firebase. Sessions are stored in Postgres (`connect-pg-simple`). Passwords and MPINs both use the `scrypt`+salt `hash.salt` format.
+
+**Roles** — the canonical backend set (from `role ===` checks across server) is: `patient`, `doctor`, `attender`, `clinic_admin`, `super_admin`. ⚠️ The client is inconsistent: `client/src/App.tsx` `ProtectedRoute allowedRoles` also references `hospital_admin` and `clinicadmin`, which the backend never emits. Treat the backend five as authoritative and be careful when matching role strings.
+
+**Core domain — token-based queue:** each appointment gets a sequential `tokenNumber` within a `doctorSchedule`. Status flows `token_started → in_progress → completed` (also `hold`, `pause`, `cancel`, `no_show`, `expired`). Attenders drive status; doctor arrival (`doctor_daily_presence`) triggers ETA recalculation and notification cascades. Walk-ins reserve tokens (`token_reservations`) that expire — a `setInterval` in `server/index.ts` calls `storage.expireStaleReservations()` every 60s. Cancellations/absences feed the wallet/refund system (`patient_wallets`, `wallet_transactions`, `appointment_refunds`).
+
+**Client pages** are role-dashboard oriented (`client/src/pages/`), guarded by `ProtectedRoute`. Data fetching is React Query against `/api/*`; routing is Wouter. The same client builds for web and for Android (Capacitor, `mode === 'capacitor'` uses relative base path).
+
+## Notes for future Claude
+- Rule #8 below references `DriveEV-API.postman_collection.json`, but the repo's collection is `RouteMappy.postman_collection.json`. Both rules #8 and the Postman/Git-template wording appear carried over from another project — confirm intent with the user rather than silently following either name.
+- `WARP.md` covers similar ground in more detail but includes generic/aspirational sections; prefer this file.
+
+---
+
 # ClinicFlow — Claude Development Rules
 
 ## Git Safety Rules

--- a/client/src/pages/auth-page.tsx
+++ b/client/src/pages/auth-page.tsx
@@ -10,7 +10,6 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Phone, Lock, ArrowLeft } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
-import { apiRequest } from "@/lib/queryClient";
 import { z } from "zod";
 
 // Staff/admin credentials
@@ -88,7 +87,14 @@ function PatientLoginForm({ onStaff }: { onStaff: () => void }) {
   const handleSubmit = async (data: PatientLoginData) => {
     setIsLoading(true);
     try {
-      const response = await apiRequest("POST", "/api/auth/patient/login", data);
+      // Use fetch directly (not apiRequest) so we can read response.status for
+      // the 423/429 branches — apiRequest throws on non-2xx before returning.
+      const response = await fetch("/api/auth/patient/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+        credentials: "include",
+      });
       const result = await response.json();
 
       if (!response.ok) {

--- a/client/src/pages/auth-page.tsx
+++ b/client/src/pages/auth-page.tsx
@@ -1,4 +1,5 @@
-// Staff/admin username+password login (/auth) with a pointer to the patient portal
+// /auth login screen: patient mobile+MPIN is primary, staff username+password is secondary
+import { useState } from "react";
 import { Link, useLocation } from "wouter";
 import { useAuth } from "@/hooks/use-auth";
 import { useForm } from "react-hook-form";
@@ -7,19 +8,35 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Phone, Lock, ArrowLeft } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+import { apiRequest } from "@/lib/queryClient";
 import { z } from "zod";
 
-// Simple schema for login
-const loginSchema = z.object({
+// Staff/admin credentials
+const staffLoginSchema = z.object({
   username: z.string().min(1, "Username is required"),
   password: z.string().min(1, "Password is required"),
 });
+type StaffLoginData = z.infer<typeof staffLoginSchema>;
 
-type LoginData = z.infer<typeof loginSchema>;
+// Patient credentials: 10-digit mobile + 4-digit MPIN
+const patientLoginSchema = z.object({
+  mobileNumber: z.string()
+    .min(10, "Mobile number must be 10 digits")
+    .max(10, "Mobile number must be 10 digits")
+    .regex(/^\d{10}$/, "Mobile number must contain only digits"),
+  mpin: z.string()
+    .length(4, "MPIN must be 4 digits")
+    .regex(/^\d{4}$/, "MPIN must contain only digits"),
+});
+type PatientLoginData = z.infer<typeof patientLoginSchema>;
 
 export default function AuthPage() {
   const [_location, navigate] = useLocation();
   const { user } = useAuth();
+  // Patient login is shown first; staff/admin is one click away
+  const [mode, setMode] = useState<"patient" | "staff">("patient");
 
   if (user) {
     navigate("/");
@@ -34,7 +51,11 @@ export default function AuthPage() {
             <CardTitle>Welcome to Clinik</CardTitle>
           </CardHeader>
           <CardContent>
-            <LoginForm />
+            {mode === "patient" ? (
+              <PatientLoginForm onStaff={() => setMode("staff")} />
+            ) : (
+              <StaffLoginForm onPatient={() => setMode("patient")} />
+            )}
           </CardContent>
         </Card>
       </div>
@@ -51,10 +72,205 @@ export default function AuthPage() {
   );
 }
 
-function LoginForm() {
+function PatientLoginForm({ onStaff }: { onStaff: () => void }) {
+  const { toast } = useToast();
+  const [isLoading, setIsLoading] = useState(false);
+  const [showMpin, setShowMpin] = useState(false);
+
+  const form = useForm<PatientLoginData>({
+    resolver: zodResolver(patientLoginSchema),
+    defaultValues: {
+      mobileNumber: "",
+      mpin: "",
+    },
+  });
+
+  const handleSubmit = async (data: PatientLoginData) => {
+    setIsLoading(true);
+    try {
+      const response = await apiRequest("POST", "/api/auth/patient/login", data);
+      const result = await response.json();
+
+      if (!response.ok) {
+        if (response.status === 423) {
+          toast({ title: "Account Locked", description: result.message, variant: "destructive" });
+        } else if (response.status === 429) {
+          toast({ title: "Too Many Attempts", description: result.message, variant: "destructive" });
+        } else {
+          toast({ title: "Login Failed", description: result.message || "Invalid credentials", variant: "destructive" });
+        }
+        return;
+      }
+
+      toast({ title: "Login Successful", description: "Welcome back!" });
+      // Force page reload to ensure auth state is updated from server session
+      setTimeout(() => {
+        window.location.href = "/home";
+      }, 500);
+    } catch (error) {
+      toast({ title: "Error", description: "Something went wrong. Please try again.", variant: "destructive" });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleMpinInput = (digit: string) => {
+    const currentMpin = form.getValues("mpin");
+    if (currentMpin.length < 4) {
+      form.setValue("mpin", currentMpin + digit);
+    }
+  };
+
+  const handleMpinClear = () => form.setValue("mpin", "");
+
+  const handleMpinBackspace = () => {
+    const currentMpin = form.getValues("mpin");
+    form.setValue("mpin", currentMpin.slice(0, -1));
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4 mt-4">
+        <FormField
+          control={form.control}
+          name="mobileNumber"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Mobile Number</FormLabel>
+              <FormControl>
+                <div className="relative">
+                  <Phone className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-500" />
+                  <Input
+                    {...field}
+                    type="tel"
+                    placeholder="10 digit mobile number"
+                    className="pl-10"
+                    maxLength={10}
+                    inputMode="numeric"
+                    pattern="[0-9]*"
+                  />
+                </div>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="mpin"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>MPIN</FormLabel>
+              <FormControl>
+                <div className="space-y-3">
+                  <div className="relative">
+                    <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-500" />
+                    <Input
+                      {...field}
+                      type={showMpin ? "text" : "password"}
+                      placeholder="4-digit MPIN"
+                      className="pl-10 text-center text-xl tracking-widest placeholder:text-sm"
+                      maxLength={4}
+                      readOnly
+                    />
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="absolute right-2 top-1/2 transform -translate-y-1/2"
+                      onClick={() => setShowMpin(!showMpin)}
+                    >
+                      {showMpin ? "Hide" : "Show"}
+                    </Button>
+                  </div>
+
+                  {/* Compact number pad for MPIN input */}
+                  <div className="grid grid-cols-3 gap-1">
+                    {[1, 2, 3, 4, 5, 6, 7, 8, 9].map((digit) => (
+                      <Button
+                        key={digit}
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="h-8 text-sm"
+                        onClick={() => handleMpinInput(digit.toString())}
+                        disabled={field.value.length >= 4}
+                      >
+                        {digit}
+                      </Button>
+                    ))}
+                    <Button type="button" variant="outline" size="sm" className="h-8 text-xs" onClick={handleMpinClear}>
+                      Clear
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-8 text-sm"
+                      onClick={() => handleMpinInput("0")}
+                      disabled={field.value.length >= 4}
+                    >
+                      0
+                    </Button>
+                    <Button type="button" variant="outline" size="sm" className="h-8 text-xs" onClick={handleMpinBackspace}>
+                      ←
+                    </Button>
+                  </div>
+                </div>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <div className="text-right">
+          <Link href="/patient-forgot-mpin">
+            <Button variant="link" className="p-0 h-auto text-sm">
+              Forgot MPIN?
+            </Button>
+          </Link>
+        </div>
+
+        <Button type="submit" className="w-full" disabled={isLoading}>
+          {isLoading ? "Logging in..." : "Login"}
+        </Button>
+
+        <div className="text-center text-sm">
+          <span className="text-gray-600">Don't have an account? </span>
+          <Link href="/patient-register">
+            <Button variant="link" className="p-0 h-auto font-semibold">
+              Register here
+            </Button>
+          </Link>
+        </div>
+
+        {/* Staff/admin entry point */}
+        <div className="relative my-2">
+          <div className="absolute inset-0 flex items-center">
+            <span className="w-full border-t" />
+          </div>
+          <div className="relative flex justify-center text-xs uppercase">
+            <span className="bg-card px-2 text-muted-foreground">or</span>
+          </div>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          className="w-full border-primary text-primary hover:bg-primary/10"
+          onClick={onStaff}
+        >
+          Staff / Admin Login
+        </Button>
+      </form>
+    </Form>
+  );
+}
+
+function StaffLoginForm({ onPatient }: { onPatient: () => void }) {
   const { loginMutation } = useAuth();
-  const form = useForm<LoginData>({
-    resolver: zodResolver(loginSchema),
+  const form = useForm<StaffLoginData>({
+    resolver: zodResolver(staffLoginSchema),
     defaultValues: {
       username: "",
       password: "",
@@ -64,6 +280,10 @@ function LoginForm() {
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit((data) => loginMutation.mutate(data))} className="space-y-4 mt-4">
+        <Button type="button" variant="ghost" size="sm" className="mb-2 -ml-2" onClick={onPatient}>
+          <ArrowLeft className="w-4 h-4 mr-2" />
+          Patient Login
+        </Button>
         <FormField
           control={form.control}
           name="username"
@@ -91,20 +311,7 @@ function LoginForm() {
           )}
         />
         <Button type="submit" className="w-full" disabled={loginMutation.isPending}>
-          Login
-        </Button>
-
-        {/* Patient portal entry point */}
-        <div className="relative my-2">
-          <div className="absolute inset-0 flex items-center">
-            <span className="w-full border-t" />
-          </div>
-          <div className="relative flex justify-center text-xs uppercase">
-            <span className="bg-card px-2 text-muted-foreground">or</span>
-          </div>
-        </div>
-        <Button asChild type="button" variant="outline" className="w-full border-primary text-primary hover:bg-primary/10">
-          <Link href="/patient-login">Patient Login</Link>
+          {loginMutation.isPending ? "Logging in..." : "Staff Login"}
         </Button>
       </form>
     </Form>


### PR DESCRIPTION
## What & why

When users clicked the **Login** button (top nav), they landed on the **staff Username/Password** screen (`/auth`). Patients were trying to log in there with their phone number as the "username" — wrong screen for them. Patients need **mobile number + 4-digit MPIN**.

## Change

Reworked **`client/src/pages/auth-page.tsx`** (the `/auth` screen) so it is patient-first:

- **Primary:** Patient login → Mobile Number + 4-digit MPIN with the on-screen number pad, "Forgot MPIN?", and "Register here" (same flow as `/patient-login` → `POST /api/auth/patient/login`, redirect to `/home`).
- **Secondary:** a **"Staff / Admin Login"** toggle that swaps the card to the Username + Password form (for attender/doctor/admin), with a **"← Patient Login"** link to swap back.

No new screens, no routing changes. `/patient-login` and the landing page are untouched. Same behavior on web and the Android (Capacitor) build.

## Notes

- Also includes an update to `CLAUDE.md` project guidance.
- Frontend-only change; `npm run check` shows no new TypeScript errors in `auth-page.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added patient and staff login modes on a single login page with a mode toggle.
  * Patient login now uses mobile number + PIN (MPIN) entry with an on-screen keypad, plus PIN show/hide controls.
  * Staff/admin login supports username/password with a “Logging in…” pending state and a back button to return to patient login.
* **Documentation**
  * Updated the project guidance file with expanded run/build/migration/seed instructions and a consolidated architecture overview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->