### PR TITLE
fix: block patient accounts from the staff/admin login form

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -139,6 +139,11 @@ export function setupAuth(app: Express) {
       if (err) return next(err);
       if (!user) return res.status(401).json({ message: "Invalid credentials" });
 
+      // Patients must use the mobile + MPIN flow, not the staff/admin form.
+      if (user.role === "patient") {
+        return res.status(403).json({ message: "Patients must use Patient Login (mobile number + MPIN)." });
+      }
+
       req.login(user, (err) => {
         if (err) return next(err);
         res.json({


### PR DESCRIPTION
## Problem

On the `/auth` screen, the **Staff / Admin Login** form lets a **patient** log in. Their account is accepted and they're signed in through the staff door.

## Root cause

The staff form posts to **`/api/login`** (via `loginMutation`). That route (`server/auth.ts:137`) authenticates on **username + password only and never checks `role`** — so any account with a password, including a patient, is accepted.

The codebase already has role-scoped routes (`/api/auth/staff/login` → attender only, `/api/auth/admin/login` → admins, `/api/auth/patient/login` → mobile+MPIN), but the staff form uses the legacy unguarded `/api/login`.

## Fix

Add a single guard in `/api/login`: after authentication, reject `role === "patient"` with **403** and a message directing them to Patient Login. Staff / doctor / admin logins through `/api/login` are unaffected.

```js
if (user.role === "patient") {
  return res.status(403).json({ message: "Patients must use Patient Login (mobile number + MPIN)." });
}
```

Chose to guard `/api/login` rather than switch the form to `/api/auth/staff/login`, because that dedicated route allows **only `attender`** and would lock out doctors and admins who currently rely on `/api/login`.

## Notes / follow-ups

- **Assumption:** patients are mobile+MPIN-first. Any legacy patient account that has *only* a username/password (no MPIN) would now be forced to the MPIN flow.
- **Cosmetic (not in this PR):** the staff form surfaces login errors via the shared fetch wrapper, so the blocked-patient toast reads as a raw `403: {...}` string. Cleaning that up touches the shared error handler and was kept out of this minimal fix.
- Backend-only change; the 7 `tsc` errors in `auth.ts` are pre-existing and unrelated to these 5 added lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)