### PR TITLE
fix: persist clinic latitude/longitude (and zipCode/openingHours) on create and update

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1258,18 +1258,20 @@ export class DatabaseStorage implements IStorage {
   }
 
   async createClinic(clinicData: typeof clinics.$inferInsert): Promise<Clinic> {
-    // Convert camelCase to snake_case for database fields
+    // Keys must be the Drizzle JS property names (e.g. zipCode, not zip_code) —
+    // Drizzle maps them to their snake_case columns. Unknown keys are silently dropped.
     const formattedData = {
       name: clinicData.name,
       address: clinicData.address,
       city: clinicData.city,
       state: clinicData.state,
-      zip_code: clinicData.zipCode,
+      zipCode: clinicData.zipCode,
       phone: clinicData.phone,
       email: clinicData.email,
-      opening_hours: clinicData.openingHours,
+      openingHours: clinicData.openingHours,
       description: clinicData.description,
-      image_url: clinicData.imageUrl
+      latitude: clinicData.latitude,
+      longitude: clinicData.longitude,
     };
     
     const [clinic] = await db.insert(clinics).values(formattedData).returning();

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1277,19 +1277,21 @@ export class DatabaseStorage implements IStorage {
   }
 
   async updateClinic(id: number, clinicData: Partial<typeof clinics.$inferInsert>): Promise<Clinic> {
-    // Convert camelCase to snake_case for database fields
+    // Keys must be the Drizzle JS property names (e.g. zipCode, not zip_code) —
+    // Drizzle maps them to their snake_case columns. Unknown keys are silently dropped.
     const formattedData: Record<string, any> = {};
-    
+
     if (clinicData.name !== undefined) formattedData.name = clinicData.name;
     if (clinicData.address !== undefined) formattedData.address = clinicData.address;
     if (clinicData.city !== undefined) formattedData.city = clinicData.city;
     if (clinicData.state !== undefined) formattedData.state = clinicData.state;
-    if (clinicData.zipCode !== undefined) formattedData.zip_code = clinicData.zipCode;
+    if (clinicData.zipCode !== undefined) formattedData.zipCode = clinicData.zipCode;
     if (clinicData.phone !== undefined) formattedData.phone = clinicData.phone;
     if (clinicData.email !== undefined) formattedData.email = clinicData.email;
-    if (clinicData.openingHours !== undefined) formattedData.opening_hours = clinicData.openingHours;
+    if (clinicData.openingHours !== undefined) formattedData.openingHours = clinicData.openingHours;
     if (clinicData.description !== undefined) formattedData.description = clinicData.description;
-    if (clinicData.imageUrl !== undefined) formattedData.image_url = clinicData.imageUrl;
+    if (clinicData.latitude !== undefined) formattedData.latitude = clinicData.latitude;
+    if (clinicData.longitude !== undefined) formattedData.longitude = clinicData.longitude;
     
     const [updatedClinic] = await db
       .update(clinics)


### PR DESCRIPTION
## Problem

Editing a clinic's **latitude/longitude** in the super-admin dashboard showed a "success" toast but kept the old coordinates. The same silent-drop affected `zipCode` and `openingHours`, and the bug also existed on clinic **creation**.

## Root cause

`storage.updateClinic` and `storage.createClinic` built their Drizzle payloads using **raw column names** (`zip_code`, `opening_hours`) and omitted `latitude`/`longitude` entirely.

Drizzle keys `.set()`/`.values()` by the **JS property name**, not the DB column name. Confirmed against the installed `drizzle-orm@0.39.3` source — `buildUpdateSet` (pg-core/dialect.cjs) filters by `set[propertyName]`:

```js
const columnNames = Object.keys(tableColumns).filter(
  (colName) => set[colName] !== undefined || ...
);
```

So `set['zip_code']` never matched the `zipCode` column → those columns were filtered out of the SQL and silently never written. Only `name, address, city, state, phone, email, description` were ever persisted on edit; `zipCode`, `openingHours`, `latitude`, `longitude` were all dropped.

## Fix

- Use the correct Drizzle property names (`zipCode`, `openingHours`) in both methods.
- Add `latitude` and `longitude` mapping to both `createClinic` and `updateClinic`.
- Removed the bogus `imageUrl`/`image_url` key (the `clinics` table has no image column), which also cleared a pre-existing TS error.

## Why this is safe (no flow breaks)

- Before, those four fields were no-ops — the SQL never touched those columns — so there is nothing working to break.
- This only affects whether a **write** lands; column definitions and all **reads** are unchanged.
- `getClinicsNearLocation` reads lat/long for distance — coordinates now persisting makes nearby-search *more* accurate.
- High-precision input is auto-rounded by Postgres to the column scale (8) — no error.
- `npm run check`: the edited regions are clean; remaining TS errors are pre-existing and unrelated.

## Files
- `server/storage.ts` — `createClinic`, `updateClinic`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated clinic data update logic to improve field assignment handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->