### PR TITLE
fix: blank white screen on clinic doctors page in the mobile app (guard Notification API)

### DIFF
--- a/client/src/pages/patient-clinic-details.tsx
+++ b/client/src/pages/patient-clinic-details.tsx
@@ -429,8 +429,9 @@ export default function PatientClinicDetails() {
             duration: 8000,
           });
 
-          // Show browser notification if permission is granted
-          if (Notification.permission === 'granted') {
+          // Show browser notification if permission is granted.
+          // Guard for the Notification API — it is absent in the Android WebView (Capacitor).
+          if (typeof window !== 'undefined' && 'Notification' in window && Notification.permission === 'granted') {
             new Notification('Booking Started!', {
               body: `Your favorited schedule is now active. Book your appointment now!`,
               icon: '/favicon.ico'
@@ -444,9 +445,17 @@ export default function PatientClinicDetails() {
     previousScheduleData.current = currentSchedules;
   }, [scheduleData, user, selectedDoctor, doctors, toast]);
 
-  // Request notification permission on component mount
+  // Request notification permission on component mount.
+  // Guard for the Notification API — it is absent in the Android WebView (Capacitor),
+  // where an unguarded reference throws and blanks the whole page (no error boundary).
   useEffect(() => {
-    if (user && user.role === 'patient' && Notification.permission === 'default') {
+    if (
+      user &&
+      user.role === 'patient' &&
+      typeof window !== 'undefined' &&
+      'Notification' in window &&
+      Notification.permission === 'default'
+    ) {
       Notification.requestPermission();
     }
   }, [user]);


### PR DESCRIPTION
## Problem

Opening a clinic's **"view doctors"** page (`/patient/clinics/:id`) works on the web but shows a **blank white screen in the Android app**.

## Root cause

The mobile app loads the **live site** in a WebView (`capacitor.config.ts` → `server.url: 'https://clinik.co.in'`), so the only difference from the web is the WebView's JS API support.

`patient-clinic-details.tsx` used the **Web Notifications API unguarded**:
- on mount: `Notification.permission` / `Notification.requestPermission()`
- in the favorite-active effect: `Notification.permission` / `new Notification(...)`

The Android WebView does **not** expose `Notification`, so the reference throws `ReferenceError: Notification is not defined`. The client has **no error boundary**, so that throw unmounts the entire React tree → blank screen. Desktop Chrome has `Notification`, which is why the web is unaffected. This was the only page touching `Notification` unguarded — `notification-popover.tsx` already guards it, which is why every other page works in the app.

## Fix

Guard every `Notification` reference with `typeof window !== 'undefined' && 'Notification' in window`, mirroring the existing pattern in `notification-popover.tsx`.

## Customer impact: none lost

Only the **desktop-only browser popup** is skipped on mobile (it never worked in the WebView anyway). All real notification channels are untouched:
- in-app toast ("🌟 Favorited Schedule is Now Active!") — still fires
- notification bell (server-polled) — still works
- native push (Capacitor `PushNotifications`) — still works
- registration OTP (SMS/Twilio) — unrelated, unaffected

## Deployment note

Because the app loads the live site in a WebView, **no APK rebuild/reinstall is needed** — merging and deploying the **web** makes the installed app work on next open.

## Repo-wide check

Audited all browser-only APIs across the client (`Notification`, `navigator.geolocation`, `navigator.permissions`, `navigator.clipboard`, `window.open`, `Audio`, `matchMedia`, `localStorage`). This was the **only** unguarded crash-at-load case. Geolocation/permission code is already guarded; the lone minor gap (`navigator.clipboard` on an admin copy button) runs in a click handler so it can't blank a page — left out to keep this PR focused.

## Files
- `client/src/pages/patient-clinic-details.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened notification system stability to prevent crashes when notification features are unavailable on certain mobile platforms and WebView environments.
  * Enhanced notification permission request logic to ensure reliable behavior across all platforms and browser configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->