### PR TITLE
fix: doctor search hides visible (booking-not-started) schedules

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1147,7 +1147,11 @@ export class DatabaseStorage implements IStorage {
         eq(doctorSchedules.doctorId, doctorId),
         gte(doctorSchedules.date, startOfDay),
         lte(doctorSchedules.date, endOfDay),
-        eq(doctorSchedules.isActive, true)
+        // Show a today schedule if booking has started (isActive) OR the attender
+        // marked it "Show to Patients" (isVisible). Previously this only checked
+        // isActive, so visible-but-booking-not-started schedules were hidden from
+        // Smart Search even though the View Doctors page showed them.
+        or(eq(doctorSchedules.isActive, true), eq(doctorSchedules.isVisible, true))
       ];
 
       if (clinicId) {


### PR DESCRIPTION
## Problem

A schedule created with **Start Booking = OFF** and **Show to Patients = ON** (`isActive = false`, `isVisible = true`) is **inconsistent** between two patient-facing screens:

- **Clinic → View Doctors** (`/patient/clinics/:id`): shows the schedule with a **"Booking Not Started"** badge ✅
- **Home → Smart Search** (search doctor name → Schedules): shows **"No Schedules Today"** ❌

## Root cause

The two screens load schedules via different backend paths:

- View Doctors → `/api/doctors/:id/schedules` (includes today's not-yet-started schedules)
- Smart Search → `/api/search` → `searchByDoctorName` → **`getDoctorTodaySchedules`**

`getDoctorTodaySchedules` (`server/storage.ts`) filtered today's schedules on **`isActive = true` only**, completely ignoring the `isVisible` ("Show to Patients") flag — which is the whole purpose of that toggle (let patients view/favorite before booking opens). So a visible-but-not-started schedule was excluded from search.

## Fix

Return a today schedule when **booking is active OR it is marked visible to patients**:

```js
// before
eq(doctorSchedules.isActive, true)
// after
or(eq(doctorSchedules.isActive, true), eq(doctorSchedules.isVisible, true))
```

This matches the View Doctors page. The schedule now appears in search with the **Book Token** button disabled (since `bookingStatus` isn't `open`) until booking actually opens.

## Impact / safety

- **Web + Android app both fixed** once the **backend** is deployed — the app loads the same live site and hits the same `/api/search`. No app rebuild needed.
- Only *widens* results to include schedules the attender explicitly made visible. Schedules left hidden (`isVisible = false` and booking not started) stay hidden.
- No other caller of `getDoctorTodaySchedules` breaks — they all want patient-visible schedules.
- `npm run check`: the edited region is clean; the two errors near this method (lines 1148–1149, date comparison) are pre-existing and unrelated.

## Files
- `server/storage.ts` — `getDoctorTodaySchedules`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where visible schedules that weren't yet active were missing from Smart Search results, ensuring all relevant schedules are displayed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->