### PR TITLE
fix: search shows "Booking Not Started" and disables booking until it opens

### DIFF
--- a/client/src/pages/patient-dashboard.tsx
+++ b/client/src/pages/patient-dashboard.tsx
@@ -282,22 +282,32 @@ export default function PatientDashboard() {
     setLocation(`/book/${doctorId}?scheduleId=${scheduleId}&clinicId=${clinicId}`);
   };
 
-  const ScheduleCard = ({ schedule, doctorId, doctorName }: { 
-    schedule: any; 
-    doctorId: number; 
-    doctorName: string; 
-  }) => (
+  const ScheduleCard = ({ schedule, doctorId, doctorName }: {
+    schedule: any;
+    doctorId: number;
+    doctorName: string;
+  }) => {
+    // Booking only opens once the attender flips "Start Booking" (isActive).
+    // A schedule can be visible (isVisible) yet not bookable; show it but block
+    // booking, exactly like the View Doctors page.
+    const bookingNotStarted = schedule.isActive === false;
+    const isBookable =
+      !bookingNotStarted &&
+      schedule.bookingStatus === 'open' &&
+      schedule.availableSlots !== 0;
+
+    return (
     <div className="p-3 bg-gray-50 rounded text-sm">
       <div className="flex justify-between items-start">
         <div className="flex-1">
           <div className="flex items-center gap-2 mb-2">
             <Clock className="h-4 w-4 text-gray-600" />
             <span className="font-medium">{schedule.startTime} - {schedule.endTime}</span>
-            <Badge 
-              size="sm" 
-              variant={schedule.bookingStatus === 'open' ? 'default' : 'secondary'}
+            <Badge
+              size="sm"
+              variant={bookingNotStarted ? 'destructive' : schedule.bookingStatus === 'open' ? 'default' : 'secondary'}
             >
-              {schedule.bookingStatus}
+              {bookingNotStarted ? 'Booking Not Started' : schedule.bookingStatus}
             </Badge>
           </div>
           
@@ -317,17 +327,18 @@ export default function PatientDashboard() {
           </div>
         </div>
         
-        <Button 
-          size="sm" 
+        <Button
+          size="sm"
           className="ml-3"
           onClick={() => handleBookAppointment(doctorId, schedule.id, schedule.clinicId)}
-          disabled={schedule.bookingStatus !== 'open' || schedule.availableSlots === 0}
+          disabled={!isBookable}
         >
           Book Token
         </Button>
       </div>
     </div>
-  );
+    );
+  };
 
   const ClinicDoctorsView = ({ clinicId }: { clinicId: number }) => {
     const { data: doctors = [], isLoading } = useQuery({

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1168,6 +1168,11 @@ export class DatabaseStorage implements IStorage {
           maxTokens: doctorSchedules.maxTokens,
           scheduleStatus: doctorSchedules.scheduleStatus,
           bookingStatus: doctorSchedules.bookingStatus,
+          // isActive = "Start Booking"; isVisible = "Show to Patients". The client
+          // needs both to render a visible-but-not-yet-bookable schedule correctly
+          // (Booking Not Started + disabled Book button), matching the View Doctors page.
+          isActive: doctorSchedules.isActive,
+          isVisible: doctorSchedules.isVisible,
           averageConsultationTime: doctorSchedules.averageConsultationTime,
           clinicName: clinics.name,
           clinicAddress: clinics.address


### PR DESCRIPTION
## Background

PR #58 made visible-but-not-yet-bookable schedules (`isVisible = true`, `isActive = false`) appear in the home **Smart Search** (consistent with View Doctors). But it exposed a pre-existing blind spot in the search's `ScheduleCard`: it judged bookability by `bookingStatus` (which defaults to `'open'`) and **ignored `isActive`** ("Start Booking"). So a not-started schedule showed an **`open` badge with an enabled Book Token**, while the **View Doctors** page correctly shows **"Booking Not Started"** and disables it.

> Note: this was **misleading UI, not a real bypass** — the server already rejects booking such schedules in `getSpecificSchedule` (requires `isActive` AND `isVisible`). This PR makes the UI honest and consistent.

## Fix (makes search match View Doctors)

1. **`server/storage.ts` → `getDoctorTodaySchedules`**: also return `isActive` and `isVisible` so the client can tell booking hasn't started.
2. **`client/src/pages/patient-dashboard.tsx` → `ScheduleCard`**:
   - Show a **"Booking Not Started"** badge when `isActive === false`.
   - Compute `isBookable = !bookingNotStarted && bookingStatus === 'open' && availableSlots !== 0` and **disable Book Token** accordingly.

## Result

A schedule that's visible but not started now appears in search with **"Booking Not Started"** and a disabled **Book Token** — exactly like View Doctors. Patients can still see/favorite it; they just can't book until the attender starts booking.

## Impact / safety

- **Web + Android app** both fixed once the backend + frontend are deployed (app loads the same live site).
- Behavior for already-bookable schedules is unchanged (`isActive` true → same `bookingStatus`/slots checks as before).
- `npm run check`: both changed files are clean; remaining errors are pre-existing and unrelated.
- Out of scope (separate, server-guarded): the standalone `/book/:id` page still renders an enabled "Book Now" if reached directly, but the server blocks the actual booking. Happy to harden that next if you want.

## Files
- `server/storage.ts`
- `client/src/pages/patient-dashboard.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)