### PR TITLE
fix: show ETA on patient My Appointments from booking (attender parity)

### DIFF
--- a/client/src/pages/booking-history.tsx
+++ b/client/src/pages/booking-history.tsx
@@ -330,8 +330,11 @@ export default function BookingHistoryPage() {
                                   </div>
                                 </div>
                                 
-                                {/* ETA Display for waiting and in-progress tokens */}
-                                {(appointment.status === "token_started" || appointment.status === "in_progress") && (
+                                {/* Show ETA for all live tokens (scheduled, token_started, in_progress, hold, etc.)
+                                    — mirrors the attender dashboard so patients see the same estimate from
+                                    booking onward, including the live update when the doctor arrives. Only
+                                    terminal/past statuses are excluded. */}
+                                {!["expired", "completed", "cancel", "no_show"].includes(appointment.status) && (
                                   <ETADisplay
                                     appointmentId={appointment.id}
                                     tokenNumber={appointment.tokenNumber}


### PR DESCRIPTION
## Problem

The attender dashboard shows each token's ETA from booking onward (token 1 → 6:00 PM, token 2 → 6:15 PM…) and updates it live when the doctor arrives (→ 7:00 / 7:15). But the patient's **My Appointments** screen showed **no ETA** for a freshly booked (`scheduled`) token — the estimate only appeared once the attender pressed **Start** (`token_started`).

## Root cause

Both screens use the **same `ETADisplay` component** and the **same backend endpoint** (`/api/appointments/:id/eta`). The only difference was the render gate:

| Screen | Gate |
|---|---|
| Attender (`attender-dashboard.tsx`) | show for all except `expired/completed/cancel/no_show` |
| Patient (`booking-history.tsx`) | show **only** `token_started`/`in_progress` |

So `scheduled` tokens were hidden on the patient side even though the backend already computes their ETA.

## Fix (frontend, one condition)

`client/src/pages/booking-history.tsx` — broaden the gate to mirror the attender:

```jsx
// before
{(appointment.status === "token_started" || appointment.status === "in_progress") && (
// after
{!["expired", "completed", "cancel", "no_show"].includes(appointment.status) && (
```

## Impact / safety

- **No backend change** — the ETA service already produces sequential ETAs for `scheduled` tokens and recalculates on doctor arrival. The patient screen now calls the same endpoint the attender already uses all day.
- Patients see the **identical, live-updating ETA** the attender sees — including the shift from 6:00 → 7:00 when the doctor is marked arrived (polls every 10s).
- Past/terminal tokens (`completed/cancel/no_show/expired`) remain excluded, so "Completed" cards show no ETA.
- `ETADisplay` already handles `scheduled` safely (it's the attender's tested path). Attender screen untouched.
- `npm run check`: changed file is clean; remaining errors are pre-existing/unrelated.

## Files
- `client/src/pages/booking-history.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Booking history now displays estimated arrival times for a broader range of live appointment statuses, enabling users to see ETAs throughout more stages of their booking lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->