### PR TITLE
fix: hide cancelled schedules from patients and unblock re-creating their time slot

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1985,9 +1985,15 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(404).json({ message: 'Doctor not found' });
       }
 
-      // Check for overlapping schedules on the same date
+      // Check for overlapping schedules on the same date. Cancelled schedules are
+      // ignored: a cancelled slot is a dead/historical row (kept for refund + audit
+      // history) and must not block re-creating a fresh schedule at the same time.
+      // Active and not-yet-started schedules still block, so two *live* overlapping
+      // schedules can never coexist.
       const existingSchedules = await storage.getDoctorSchedules(doctorId);
-      const overlappingSchedule = existingSchedules.find(schedule => {
+      const overlappingSchedule = existingSchedules
+        .filter(schedule => schedule.status !== 'cancelled' && !schedule.cancelReason)
+        .find(schedule => {
         const scheduleDate = new Date(schedule.date);
         const newDate = new Date(validData.date);
         

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1153,8 +1153,11 @@ export class DatabaseStorage implements IStorage {
         // Smart Search even though the View Doctors page showed them.
         or(eq(doctorSchedules.isActive, true), eq(doctorSchedules.isVisible, true)),
         // Never surface cancelled schedules to patients. A cancelled schedule keeps
-        // isVisible=true, so without this it would still appear (mislabelled as
-        // "Booking Not Started"). cancelReason is the definitive cancellation marker.
+        // isVisible=true but is marked by status='cancelled' + cancelReason, so without
+        // this it would still appear (mislabelled "Booking Not Started"). Exclude on both
+        // markers so detection matches the schedule-creation overlap guard exactly and a
+        // status-cancelled row can never leak even if cancelReason were ever empty.
+        ne(doctorSchedules.status, 'cancelled'),
         isNull(doctorSchedules.cancelReason)
       ];
 
@@ -2851,10 +2854,12 @@ export class DatabaseStorage implements IStorage {
     if (visibleOnly) {
       // For patient views, only show visible schedules...
       conditions.push(eq(doctorSchedules.isVisible, true));
-      // ...and never a cancelled one. Cancellation leaves isVisible=true, so a
-      // cancelled schedule would otherwise still render on the View Doctors page
-      // (mislabelled "Booking Not Started"). The patient is notified + refunded
-      // separately; the dead slot should simply disappear from the booking list.
+      // ...and never a cancelled one. Cancellation leaves isVisible=true but sets
+      // status='cancelled' + cancelReason. Exclude on both markers so this matches the
+      // overlap guard's definition of "cancelled" (a status-cancelled row can never leak
+      // to patients even if cancelReason were somehow empty). The patient is notified +
+      // refunded separately; the dead slot should simply disappear from the booking list.
+      conditions.push(ne(doctorSchedules.status, 'cancelled'));
       conditions.push(isNull(doctorSchedules.cancelReason));
     }
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -36,7 +36,7 @@ import {
   type AppointmentRefund,
   type TokenReservation
 } from "@shared/schema";
-import { eq, or, and, sql, inArray, lte, gte, count, not, gt, lt, getTableColumns, isNotNull, ne, max } from "drizzle-orm";
+import { eq, or, and, sql, inArray, lte, gte, count, not, gt, lt, getTableColumns, isNotNull, isNull, ne, max } from "drizzle-orm";
 import { db } from "./db";
 import session from "express-session";
 import connectPg from "connect-pg-simple";
@@ -1151,7 +1151,11 @@ export class DatabaseStorage implements IStorage {
         // marked it "Show to Patients" (isVisible). Previously this only checked
         // isActive, so visible-but-booking-not-started schedules were hidden from
         // Smart Search even though the View Doctors page showed them.
-        or(eq(doctorSchedules.isActive, true), eq(doctorSchedules.isVisible, true))
+        or(eq(doctorSchedules.isActive, true), eq(doctorSchedules.isVisible, true)),
+        // Never surface cancelled schedules to patients. A cancelled schedule keeps
+        // isVisible=true, so without this it would still appear (mislabelled as
+        // "Booking Not Started"). cancelReason is the definitive cancellation marker.
+        isNull(doctorSchedules.cancelReason)
       ];
 
       if (clinicId) {
@@ -2845,8 +2849,13 @@ export class DatabaseStorage implements IStorage {
     }
 
     if (visibleOnly) {
-      // For patient views, only show visible schedules
+      // For patient views, only show visible schedules...
       conditions.push(eq(doctorSchedules.isVisible, true));
+      // ...and never a cancelled one. Cancellation leaves isVisible=true, so a
+      // cancelled schedule would otherwise still render on the View Doctors page
+      // (mislabelled "Booking Not Started"). The patient is notified + refunded
+      // separately; the dead slot should simply disappear from the booking list.
+      conditions.push(isNull(doctorSchedules.cancelReason));
     }
 
     // Join with users table to get creator information


### PR DESCRIPTION
## Problem

When an attender cancels a schedule (e.g. Dr. Ashok Reddy, doctor unavailable):

1. **Patient side** — the cancelled schedule still appears on the **View Doctors** page and **Smart Search**, mislabelled **"Booking Not Started"**.
2. **Attender side** — trying to create a **new schedule for the same doctor at the same time** fails with `400 "Schedule overlaps with an existing schedule for this date"`.

## Root cause

A cancelled schedule is marked only by `cancelReason` (+ `status='cancelled'`, `isActive=false`) and **keeps `isVisible=true`**. Two code paths don't read those markers:

- The **patient-facing schedule queries** never select/read `cancelReason`, so they decide the badge from `isActive`/`scheduleStatus` only → a cancelled schedule falls into the "Booking Not Started" branch (`patient-clinic-details.tsx:818`).
- The **schedule-creation overlap guard** (`routes.ts:1990`) tests every existing schedule on that date, including cancelled ones, so the dead slot blocks re-creation.

The attender dashboard shows "Cancelled" correctly because its derivation keys off `cancelReason` (`storage.ts:3869`) — the two views simply disagreed on how to detect "cancelled".

## Fix

- **`server/routes.ts`** — the overlap check now skips cancelled schedules (`status !== 'cancelled' && !cancelReason`) before testing time overlap. Active and not-yet-started schedules still block, so two **live** overlapping schedules can never coexist; only cancelled (dead) slots become re-creatable.
- **`server/storage.ts`** — `getDoctorSchedules` (patient/`visibleOnly` path) and `getDoctorTodaySchedules` (Smart Search) now exclude cancelled schedules via `cancelReason IS NULL`, so they disappear from patient-facing lists instead of showing "Booking Not Started".

## Why this is safe (impact analysis)

- **All callers of the changed patient queries are patient-facing.** Attender/doctor/admin go through `getDoctorSchedules` with `visibleOnly=false` (cancelled still shown), and the attender "Today's Schedules" card uses `getAttenderSchedulesToday` (untouched).
- **Refund flow untouched** — `processScheduleCancellationRefunds` reads the `appointments` table (`isRefundEligible`, `hasBeenRefunded`, paid, status not completed/no_show/expired), not these schedule queries. Doctor-unavailable refunds to un-consulted patients are unchanged.
- **No duplicate live schedules** — only cancelled rows are excluded from the overlap guard; non-overlapping same-day schedules (e.g. 09:00–14:00 + 14:30–19:00) still work exactly as before.
- **Booking can't target a cancelled slot** — `getSpecificSchedule` already requires `isActive=true`, so a cancelled schedule was never bookable.
- `cancelReason` is required by the cancel route and set by no other path, so `cancelReason IS NULL` ⟺ "not cancelled" — precise, no false hides.

No schema change, no migration. Pre-existing TypeScript errors in `storage.ts`/`schema.ts`/`vite.ts` are unchanged by this PR.

## Manual test plan

1. Attender cancels a schedule → patient View Doctors / Search no longer lists it (previously "Booking Not Started"); attender dashboard still shows "Cancelled".
2. Attender re-creates a schedule for the same doctor + same time → succeeds (previously 400 overlap).
3. Create two non-overlapping same-day schedules → still allowed.
4. Create two genuinely overlapping active schedules → still blocked.
5. Cancel a schedule with paid, un-consulted patients → those patients still refunded to wallet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cancelled doctor schedules no longer prevent creating a new schedule for the same time slot.
  * Patient-facing schedule listings and search results now hide cancelled (and cancellation-reason) entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->