### PR TITLE
fix: exclude cancelled schedules from booking page and favorites (follow-up to #62)

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -2951,6 +2951,12 @@ export class DatabaseStorage implements IStorage {
           eq(doctorSchedules.doctorId, doctorId),
           sql`DATE(${doctorSchedules.date}) = DATE(${date.toISOString()})`,
           eq(doctorSchedules.isVisible, true), // Only show visible schedules to patients
+          // Never offer a cancelled schedule for booking. Cancellation leaves
+          // isVisible=true, so without this the booking page renders a "Book Now"
+          // card for a dead slot. Match the same cancelled-detection used by the
+          // other patient surfaces (status + cancelReason).
+          ne(doctorSchedules.status, 'cancelled'),
+          isNull(doctorSchedules.cancelReason)
           // Show schedules unless they are completed (patients should see completed/closed for info)
         )
       )
@@ -3499,7 +3505,15 @@ export class DatabaseStorage implements IStorage {
         .innerJoin(users, eq(patientFavorites.doctorId, users.id))
         .innerJoin(doctorSchedules, eq(patientFavorites.scheduleId, doctorSchedules.id))
         .innerJoin(clinics, eq(patientFavorites.clinicId, clinics.id))
-        .where(eq(patientFavorites.patientId, patientId))
+        // Exclude favourites whose schedule has been cancelled — a cancelled
+        // schedule keeps isVisible=true, so without this filter it would still
+        // surface (with a bookable card) in the patient's Favorites list. Same
+        // cancelled-detection as the other patient surfaces (status + cancelReason).
+        .where(and(
+          eq(patientFavorites.patientId, patientId),
+          ne(doctorSchedules.status, 'cancelled'),
+          isNull(doctorSchedules.cancelReason)
+        ))
         .orderBy(patientFavorites.createdAt);
 
       return favorites;


### PR DESCRIPTION
## Why this follow-up

PR #62 hid cancelled schedules from **View Doctors**, **Smart Search**, and the **patient dashboard** — but I missed **two other patient entry points** to schedule data. This PR closes them.

Confirmed live (doctor 114, 2026-06-24):

| id | status | is_active | is_visible | cancel_reason |
|----|--------|-----------|-----------|---------------|
| 194 | cancelled | f | t | `emergency` |
| 198 | active | t | t | _(null)_ |

The booking page rendered **two "Book Now" cards** — schedule 194 (genuinely cancelled, but still `is_visible=true`) plus the legitimate active 198. Not a duplicate-schedule bug — a cancellation that leaked because this query didn't check the cancellation markers.

## What changed (`server/storage.ts`)

Both methods now apply the same cancelled-detection used by the surfaces fixed in #62 — `status != 'cancelled' AND cancelReason IS NULL`:

1. **`getDoctorAvailableTimeSlots`** (the `/book/:id` booking page) — gated only on `isVisible=true`; now also excludes cancelled. Fixes the "two Book Now" screenshot.
2. **`getPatientFavorites`** (Favorites list) — inner-joined `doctorSchedules` with no cancelled filter; a favourited schedule that was later cancelled stayed in the list with a bookable card. Now excluded.

## Complete patient-surface coverage (after this PR)

| Method | Screen | Cancelled excluded? |
|--------|--------|---------------------|
| `getDoctorSchedules` (visibleOnly) | View Doctors | ✅ #62 |
| `getDoctorTodaySchedules` | Search + dashboard | ✅ #62 |
| `getDoctorAvailableTimeSlots` | Booking page | ✅ **this PR** |
| `getPatientFavorites` | Favorites | ✅ **this PR** |
| `getSpecificSchedule` | booking POST validation | ✅ already (requires `isActive=true`) |

## Safety

- **Staff views unaffected** — `getAttenderSchedulesToday` has no `isVisible`/cancel gating (still shows "Cancelled" via `cancelReason`), and staff `getDoctorSchedules` calls pass `visibleOnly=false`.
- **Works on existing data** — keys on `cancelReason`/`status`, which existing cancelled rows already have. No backfill, no schema change, no migration.
- Typecheck: total tsc errors unchanged (79 → 79, all pre-existing).

## Manual test plan

1. `/book/114` for Dr. Ashok Reddy on 2026-06-24 → only schedule 198 shows; cancelled 194 is gone (was two "Book Now").
2. Favourite a schedule, then cancel it as attender → it disappears from the patient's Favorites.
3. Active, non-cancelled schedules still book normally.
4. Attender dashboard still shows the cancelled schedule as "Cancelled".

🤖 Generated with [Claude Code](https://claude.com/claude-code)