### PR TITLE
fix: friendlier error when an attender creates an overlapping schedule

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2022,8 +2022,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
       });
 
       if (overlappingSchedule) {
-        return res.status(400).json({ 
-          message: 'Schedule overlaps with an existing schedule for this date' 
+        return res.status(400).json({
+          message: `${doctor.name} already has a schedule from ${overlappingSchedule.startTime} to ${overlappingSchedule.endTime} on this date. Please choose a different time, or remove the existing schedule first.`
         });
       }
 


### PR DESCRIPTION
## Problem

When an attender tries to create a schedule that overlaps an existing one for the same doctor/date, the API returned a generic, technical message:

> `Schedule overlaps with an existing schedule for this date`

It's surfaced as a toast on the Doctor Schedules page, but it doesn't tell the attender *which* schedule clashed or what to do.

## Change

`server/routes.ts` (`POST /api/doctors/:id/schedules` overlap guard) now returns a specific, friendly message naming the doctor and the conflicting time window:

> `Dr Rajendra Prasad already has a schedule from 14:00 to 17:00 on this date. Please choose a different time, or remove the existing schedule first.`

(Uses the already-fetched `doctor` object and the matched `overlappingSchedule`'s `startTime`/`endTime` — no new queries.)

## Scope / safety

- Message-text only; the overlap detection logic is unchanged (cancelled schedules are still skipped, per #62).
- The client already toasts `error.message` on a 400 (doctor-schedules.tsx:204-208), so this flows straight through to the user with no client change.
- Typecheck: total tsc errors unchanged (79 → 79, all pre-existing).

## Test plan

1. Create a schedule for a doctor (e.g. 14:00–17:00).
2. Try to create another overlapping one (e.g. 15:00–18:00) same doctor/date → toast now names the doctor + existing time window.
3. Non-overlapping times still create successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)