### PR TITLE
fix: Doctor Schedules / Doctor Management toasts never render (wrong use-toast store)

### DIFF
--- a/client/src/pages/doctor-management.tsx
+++ b/client/src/pages/doctor-management.tsx
@@ -8,7 +8,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
-import { useToast } from "@/components/ui/use-toast";
+import { useToast } from "@/hooks/use-toast";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";

--- a/client/src/pages/doctor-schedules.tsx
+++ b/client/src/pages/doctor-schedules.tsx
@@ -8,7 +8,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
-import { useToast } from "@/components/ui/use-toast";
+import { useToast } from "@/hooks/use-toast";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Table, TableBody, TableCaption, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Plus, Edit, Trash2, Calendar, Clock } from "lucide-react";


### PR DESCRIPTION
## Problem

On the **Doctor Schedules** page, creating an overlapping schedule (or any create/update/delete) showed **no toast at all** — not the success message, not the error. This is why the friendly overlap message from #64 never appeared after deployment.

## Root cause

The repo has **two separate toast stores**:
- `@/hooks/use-toast` — the canonical one, used by 29 pages, and read by the `<Toaster/>` that `App.tsx` mounts (`@/components/ui/toaster` imports from `@/hooks/use-toast`).
- `@/components/ui/use-toast` — a second, self-contained implementation with its own internal state.

`doctor-schedules.tsx` and `doctor-management.tsx` imported `useToast` from `@/components/ui/use-toast`. Their `toast()` calls pushed into that store, but the mounted `<Toaster/>` only renders the `@/hooks/use-toast` store — so the toasts were created and silently dropped.

## Fix

Point both pages at the canonical `@/hooks/use-toast` (one-line import change each). No API difference — same `useToast()` / `toast()` signature.

## Effect

- The friendly schedule-overlap error (#64) now actually appears.
- "Schedule created/updated/deleted" success toasts on these pages now appear too.

## Scope / safety

- Two import-line changes only; no logic touched.
- Typecheck: total tsc errors unchanged (79 → 79).

## Test plan

1. Doctor Schedules → create an overlapping schedule → friendly error toast appears.
2. Create a valid schedule → "Schedule created successfully" toast appears.
3. Doctor Management → trigger any create/update action → toast appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated toast notifications on the doctor management and doctor schedules pages to use a consistent, shared implementation, helping ensure success and error messages display reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->