### PR TITLE
fix: block booking an ended schedule from Search results

### DIFF
--- a/client/src/pages/patient-dashboard.tsx
+++ b/client/src/pages/patient-dashboard.tsx
@@ -291,8 +291,25 @@ export default function PatientDashboard() {
     // A schedule can be visible (isVisible) yet not bookable; show it but block
     // booking, exactly like the View Doctors page.
     const bookingNotStarted = schedule.isActive === false;
+
+    // Block booking once today's schedule end time has passed. The Search card was
+    // meant to match the View Doctors page (patient-clinic-details.tsx) but only
+    // copied the "booking not started" check, so an ended schedule still showed an
+    // enabled "Book Token" button here while View Doctors correctly disabled it.
+    const now = new Date();
+    const schDate = new Date(schedule.date);
+    const isTodaySchedule = now.toDateString() === schDate.toDateString();
+    let isEndTimePassed = false;
+    if (isTodaySchedule && schedule.endTime) {
+      const [endHour, endMin] = schedule.endTime.split(':').map(Number);
+      const endTimeToday = new Date();
+      endTimeToday.setHours(endHour, endMin, 0, 0);
+      isEndTimePassed = now > endTimeToday;
+    }
+
     const isBookable =
       !bookingNotStarted &&
+      !isEndTimePassed &&
       schedule.bookingStatus === 'open' &&
       schedule.availableSlots !== 0;
 
@@ -305,9 +322,9 @@ export default function PatientDashboard() {
             <span className="font-medium">{schedule.startTime} - {schedule.endTime}</span>
             <Badge
               size="sm"
-              variant={bookingNotStarted ? 'destructive' : schedule.bookingStatus === 'open' ? 'default' : 'secondary'}
+              variant={bookingNotStarted ? 'destructive' : isEndTimePassed ? 'secondary' : schedule.bookingStatus === 'open' ? 'default' : 'secondary'}
             >
-              {bookingNotStarted ? 'Booking Not Started' : schedule.bookingStatus}
+              {bookingNotStarted ? 'Booking Not Started' : isEndTimePassed ? 'Ended' : schedule.bookingStatus}
             </Badge>
           </div>
           


### PR DESCRIPTION
## Problem

A schedule whose end time had already passed was still bookable from **Search** (`/home`): it showed an **"open"** badge and an enabled **"Book Token"** button. The **View Doctors** page (`/patient/clinics/:id`) correctly showed *"Schedule ended at HH:MM"* and disabled booking for the same schedule.

Reproduced live: Dr Sangeetha Raj, 14:00–15:00, after 15:00 — View Doctors blocked, Search still offered "Book Token".

## Root cause

The Search card (`patient-dashboard.tsx`) computed `isBookable` with no end-time check:

```js
const isBookable = !bookingNotStarted && schedule.bookingStatus === 'open' && schedule.availableSlots !== 0;
```

A comment above it says it should block booking *"exactly like the View Doctors page"*, but only the `bookingNotStarted` check was copied — the `!isEndTimePassed` condition that View Doctors uses (`patient-clinic-details.tsx:568`) was missing.

## Fix (client-side parity)

- Compute `isEndTimePassed` for today's schedule using the same logic as View Doctors.
- Add `!isEndTimePassed` to `isBookable` → "Book Token" is disabled once the time has passed.
- Show an **"Ended"** badge instead of a misleading "open" badge.

## Scope / known limitation

This is a **display guard only**, matching View Doctors. The **server booking endpoint still does not enforce end time** (`getSpecificSchedule` keys on `isActive`/`isVisible`, not the clock), so a direct API/booking call could still create an appointment on an ended schedule. Server-side enforcement is a separate change pending a product decision (how ended schedules should behave for booking and for the attender's Start/Hold/No-Show actions).

## Scope / safety

- One file, client only; no API or data changes.
- Typecheck: total tsc errors unchanged (79 → 79).

## Test plan

1. Search a doctor whose today schedule has ended → badge shows "Ended", "Book Token" disabled (was "open" + enabled).
2. Search a doctor whose schedule is still active → "Book Token" works as before.
3. Behaviour now matches the View Doctors page for the same schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved booking availability on today’s schedules so bookings are no longer allowed after a schedule’s end time has passed.
  * Updated schedule status indicators to show an **Ended** state for completed schedules happening today.

* **Style**
  * Refined booking badge text and styling to better reflect current schedule availability, while preserving existing statuses such as **Booking Not Started**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->