### PR TITLE
fix: interpret schedule end time as IST in resolve-tokens ended-check (CF-002)

### DIFF
--- a/server/services/schedule-resolution.ts
+++ b/server/services/schedule-resolution.ts
@@ -49,12 +49,14 @@ export function isScheduleEnded(schedule: ScheduleLike): boolean {
   if (!schedule?.date || !schedule?.endTime) return false;
   const [h, mi] = String(schedule.endTime).split(':').map(Number);
   if (Number.isNaN(h) || Number.isNaN(mi)) return false;
-  // date column is "YYYY-MM-DD" -> parsed as UTC midnight; shift the IST wall-clock to its UTC instant.
-  const end = new Date(String(schedule.date));
-  if (Number.isNaN(end.getTime())) return false;
-  const utcMinutes = h * 60 + mi - IST_OFFSET_MINUTES;
-  end.setUTCHours(Math.floor(utcMinutes / 60), utcMinutes % 60, 0, 0);
-  return new Date() > end;
+  // date column is "YYYY-MM-DD" -> parsed as UTC midnight.
+  const base = new Date(String(schedule.date));
+  if (Number.isNaN(base.getTime())) return false;
+  // endTime is an IST wall-clock; shift it to its UTC instant with signed minute arithmetic.
+  // (Adding total minutes as ms avoids the hour/minute decomposition bug for IST times before
+  //  05:30, where the offset goes negative and floor/modulo would land an hour early.)
+  const endUtcMs = base.getTime() + (h * 60 + mi - IST_OFFSET_MINUTES) * 60 * 1000;
+  return Date.now() > endUtcMs;
 }
 
 // Per-schedule ownership: a user may only resolve a schedule they actually manage.

--- a/server/services/schedule-resolution.ts
+++ b/server/services/schedule-resolution.ts
@@ -39,14 +39,21 @@ interface ScheduleLike {
 
 const SETTLEABLE_STATUSES = ['token_started', 'hold', 'scheduled'];
 
-// Combine the schedule's date (YYYY-MM-DD) + endTime (HH:MM[:SS]) in server-local time
-// and report whether it is now in the past. Server-side guard — never trust a client "ended" flag.
+// Schedule start/end times are stored as clinic-local IST "HH:MM" (matches ETAService).
+const IST_OFFSET_MINUTES = 330; // UTC+5:30
+
+// Whether the schedule's end time (IST wall-clock on its date) is now in the past.
+// Server-side guard — never trust a client "ended" flag. Must interpret endTime as IST,
+// otherwise a UTC-hosted server reads "17:00" as 17:00 UTC (22:30 IST) and wrongly rejects.
 export function isScheduleEnded(schedule: ScheduleLike): boolean {
   if (!schedule?.date || !schedule?.endTime) return false;
-  const [y, mo, d] = String(schedule.date).split('-').map(Number);
   const [h, mi] = String(schedule.endTime).split(':').map(Number);
-  if (!y || !mo || !d) return false;
-  const end = new Date(y, mo - 1, d, h || 0, mi || 0, 0, 0);
+  if (Number.isNaN(h) || Number.isNaN(mi)) return false;
+  // date column is "YYYY-MM-DD" -> parsed as UTC midnight; shift the IST wall-clock to its UTC instant.
+  const end = new Date(String(schedule.date));
+  if (Number.isNaN(end.getTime())) return false;
+  const utcMinutes = h * 60 + mi - IST_OFFSET_MINUTES;
+  end.setUTCHours(Math.floor(utcMinutes / 60), utcMinutes % 60, 0, 0);
   return new Date() > end;
 }
 


### PR DESCRIPTION
## Bug

After deploying CF-002, resolving a genuinely-ended schedule failed with:

> 400 — "Schedule has not ended yet — tokens can only be resolved after the schedule end time."

…even though the attender dashboard correctly showed the schedule as **Ended** and surfaced the "needs resolution" banner.

## Root cause — timezone

`isScheduleEnded` built the end time in the **server's local timezone** (`new Date(y, mo-1, d, h, mi)`). Production runs in **UTC**, so a schedule ending at `"17:00"` was interpreted as **17:00 UTC = 22:30 IST**. At ~17:53 IST (12:23 UTC) the server judged it "not ended yet" and returned 400. Meanwhile the **browser runs in IST**, so the client correctly showed "Ended" — hence the client/server disagreement.

Schedule `startTime`/`endTime` are stored as **clinic-local IST `"HH:MM"`** (same as `ETAService`).

## Fix

Interpret `endTime` as IST and convert to its UTC instant before comparing to `now`, reusing the established `IST_OFFSET_MINUTES = 330` convention from `server/services/eta.ts`:

```ts
const end = new Date(String(schedule.date));            // "YYYY-MM-DD" -> UTC midnight
const utcMinutes = h * 60 + mi - IST_OFFSET_MINUTES;    // shift IST wall-clock to UTC
end.setUTCHours(Math.floor(utcMinutes / 60), utcMinutes % 60, 0, 0);
return new Date() > end;
```

Now the server and the IST client agree on "ended."

## Verification
- Typecheck: 79/79 baseline — 0 new errors.
- 34/34 pure-logic assertions pass (ended-check replica updated to IST-aware).
- Build succeeds.

Single-file change to `server/services/schedule-resolution.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schedule end-time checks so events are evaluated using a consistent IST-to-UTC conversion.
  * Added stronger validation for schedule date and end-time values, reducing incorrect end-status results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->