### PR TITLE
fix: disable "Mark as Arrived" once schedule end time has passed (CF-002)

### DIFF
--- a/client/src/pages/attender-dashboard.tsx
+++ b/client/src/pages/attender-dashboard.tsx
@@ -968,10 +968,13 @@ export default function AttenderDashboard() {
                                           )}
                                         </div>
                                         <div className="flex flex-wrap gap-2 items-center">
+                                          {/* Lock arrival once the schedule's end time has passed — a doctor can't
+                                              "arrive" for an over schedule. If the attender forgot to mark arrival,
+                                              recovery is via Resolve -> "Doctor saw everyone — mark all completed". */}
                                           <Button
                                             variant={getPresenceData(doctorData.doctor.id, schedule.id).hasArrived ? "default" : "outline"}
                                             className="gap-2"
-                                            disabled={getPresenceData(doctorData.doctor.id, schedule.id).hasArrived || schedule.scheduleStatus === 'completed'}
+                                            disabled={getPresenceData(doctorData.doctor.id, schedule.id).hasArrived || schedule.scheduleStatus === 'completed' || isScheduleEnded(schedule)}
                                             onClick={() => handleToggleDoctorArrival(
                                               doctorData.doctor.id,
                                               schedule.clinicId || doctorData.clinicId || user?.clinicId,


### PR DESCRIPTION
## What & why

A doctor can't "arrive" for a schedule that is already over. The attender dashboard's **"Mark as Arrived"** button was only disabled when the doctor had already arrived or the schedule was `completed`. This adds the existing `isScheduleEnded` predicate to the `disabled` condition so the button locks once the schedule end time passes.

This is the follow-up to PR #67 (CF-002 ended-schedule token resolution) and PR #68 (IST timezone fix), kept as its own PR per request.

## Change

`client/src/pages/attender-dashboard.tsx` — one line:

```diff
- disabled={...hasArrived || schedule.scheduleStatus === 'completed'}
+ disabled={...hasArrived || schedule.scheduleStatus === 'completed' || isScheduleEnded(schedule)}
```

Reuses the **same** `isScheduleEnded` helper that already gates the Resolve banner/button, so the moment "Mark as Arrived" locks, the amber **"Resolve N Token(s)"** button appears in the same row.

## Recovery for "attender forgot to mark arrival"

No regression: if the attender forgot to mark the doctor arrived and notices after the schedule ended, recovery is via **Resolve → "Doctor saw everyone — mark all completed"** (settles leftover tokens to `completed`, no refund). No need to fake an arrival on an over schedule.

## Verification

- `npm run check` — **79 errors (baseline, no new errors)**; none in the touched file
- `npm run build` — green (`dist/index.js` 399.5kb)
- Standalone logic test mirroring the exact disable predicate — **10/10 passing** (normal flow unaffected; ended schedules lock arrival; locks exactly when Resolve becomes available; bad/missing data never falsely "ends")

🤖 Generated with [Claude Code](https://claude.com/claude-code)