### PR TITLE
fix: add device_tokens migration so FCM push tokens persist in prod

### DIFF
--- a/migrations/0036_create_device_tokens.sql
+++ b/migrations/0036_create_device_tokens.sql
@@ -1,0 +1,12 @@
+-- Create device_tokens table for FCM push notifications.
+-- Mirrors shared/schema.ts deviceTokens; was added via db:push in dev but never
+-- migrated to prod, so register-token inserts and sendPushToUser selects failed silently.
+CREATE TABLE IF NOT EXISTS "device_tokens" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "user_id" integer NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+  "token" text NOT NULL UNIQUE,
+  "platform" varchar(20) NOT NULL DEFAULT 'android',
+  "created_at" timestamp DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS "device_tokens_user_id_idx" ON "device_tokens" ("user_id");


### PR DESCRIPTION
## Root cause

Background push notifications never worked because **the `device_tokens` table does not exist in production**.

- `device_tokens` is defined in `shared/schema.ts:194` and was created in **dev via `db:push`**, but **no migration file was ever generated** for it.
- Prod is updated via **`db:migrate`** (the custom file runner in `migrations/run.ts`), which only runs `migrations/*.sql` files — so prod never got the table.
- Consequence: `POST /api/notifications/register-token` (`db.insert(deviceTokens)`) and `sendPushToUser` (`db.select().from(deviceTokens)`) **failed silently** → no FCM token was ever stored → **no push was ever sent** (foreground or background).
- The in-app bell *appeared* to work only because `notification-popover.tsx` polls the `notifications` table on app open — that's not a real push.

Verified live: `\dt` on prod shows all tables (`appointments`, `users`, `notifications`, …) **except** `device_tokens`.

## Change

Adds `migrations/0036_create_device_tokens.sql` — a hand-written migration matching `shared/schema.ts` exactly:

```sql
CREATE TABLE IF NOT EXISTS "device_tokens" (
  "id" serial PRIMARY KEY NOT NULL,
  "user_id" integer NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
  "token" text NOT NULL UNIQUE,
  "platform" varchar(20) NOT NULL DEFAULT 'android',
  "created_at" timestamp DEFAULT CURRENT_TIMESTAMP
);
CREATE INDEX IF NOT EXISTS "device_tokens_user_id_idx" ON "device_tokens" ("user_id");
```

Idempotent (`IF NOT EXISTS`), sorts after `0035`, and is the only pending migration file.

## Deploy steps (Option 2 — `db:migrate`)

1. Merge.
2. On prod, **before** running migrate, sanity-check the tracker isn't missing older entries:
   ```sql
   SELECT name FROM migrations ORDER BY name;
   ```
   The runner executes every `.sql` not listed there. Most older files are `IF NOT EXISTS`, but confirm `0035` is present so only `0036` runs.
3. Run `npm run db:migrate`.
4. Verify: `SELECT * FROM device_tokens ORDER BY created_at DESC;` (empty is fine).
5. **Re-login on the test device** so `registerFcmToken()` stores a token → confirm a row appears.
6. Re-test push: foreground first (should now deliver a real push), then background.

## Note — this unblocks push, but background tray display may still need a follow-up

Even with tokens persisting, background tray notifications can still be blocked by the **missing `appointments` notification channel** (server sends `channelId: 'appointments'`, but no client `createChannel` / no manifest default channel). If background is still silent after this, that's the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support for push notifications by ensuring devices can be registered reliably.
  * Reduced the chance of notification-related failures in production by adding the missing backend support needed to store device information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->