### PR TITLE
feat: load Firebase service account from FIREBASE_SERVICE_ACCOUNT env var

### DIFF
--- a/server/firebase-admin.ts
+++ b/server/firebase-admin.ts
@@ -9,20 +9,34 @@ import { eq } from 'drizzle-orm';
 
 let adminApp: App | null = null;
 
+// Read the service account JSON, preferring an env var (survives container redeploys
+// on hosts like Coolify where the git-ignored key file is wiped on each deploy) and
+// falling back to a file on disk for local development.
+// FIREBASE_SERVICE_ACCOUNT may hold the raw JSON or a base64-encoded copy of it.
+function loadServiceAccount(): Record<string, any> | null {
+  const fromEnv = process.env.FIREBASE_SERVICE_ACCOUNT?.trim();
+  if (fromEnv) {
+    const raw = fromEnv.startsWith('{') ? fromEnv : Buffer.from(fromEnv, 'base64').toString('utf-8');
+    return JSON.parse(raw);
+  }
+  // Try both server/ (development) and dist/ (production) locations
+  const candidates = [
+    resolve(process.cwd(), 'server', 'firebase-service-account.json'),
+    resolve(process.cwd(), 'dist', 'firebase-service-account.json'),
+  ];
+  const keyPath = candidates.find(p => existsSync(p));
+  if (!keyPath) return null;
+  return JSON.parse(readFileSync(keyPath, 'utf-8'));
+}
+
 function getAdminApp(): App | null {
   if (adminApp) return adminApp;
   try {
-    // Try both dist/server/ (production) and server/ (development) locations
-    const candidates = [
-      resolve(process.cwd(), 'server', 'firebase-service-account.json'),
-      resolve(process.cwd(), 'dist', 'firebase-service-account.json'),
-    ];
-    const keyPath = candidates.find(p => existsSync(p));
-    if (!keyPath) {
-      console.warn('firebase-service-account.json not found — push notifications disabled');
+    const serviceAccount = loadServiceAccount();
+    if (!serviceAccount) {
+      console.warn('Firebase service account not found (set FIREBASE_SERVICE_ACCOUNT or add the key file) — push notifications disabled');
       return null;
     }
-    const serviceAccount = JSON.parse(readFileSync(keyPath, 'utf-8'));
     if (getApps().length === 0) {
       adminApp = initializeApp({ credential: cert(serviceAccount) });
     } else {


### PR DESCRIPTION
## Why

Server-side push (`sendPushToUser`) needs the Firebase **service-account key** on the prod server. Today `firebase-admin.ts` only reads it from a **file on disk** — but that key file is **git-ignored**, and Coolify **rebuilds the container from git on every redeploy**, so any manually-placed file is **wiped on each deploy**. Result: push stays disabled in prod.

This is the server half of getting FCM push working (the client half — `google-services.json` in the APK — is handled separately, outside git).

## Change

`server/firebase-admin.ts` — extract credential loading into `loadServiceAccount()` that:
1. Reads **`FIREBASE_SERVICE_ACCOUNT`** env var first (accepts **raw JSON** or **base64**), else
2. Falls back to the existing file lookup (`server/…` then `dist/…`) for local dev.

Backward-compatible — when the env var is unset, behaviour is identical to before.

```ts
function loadServiceAccount(): Record<string, any> | null {
  const fromEnv = process.env.FIREBASE_SERVICE_ACCOUNT?.trim();
  if (fromEnv) {
    const raw = fromEnv.startsWith('{') ? fromEnv : Buffer.from(fromEnv, 'base64').toString('utf-8');
    return JSON.parse(raw);
  }
  const candidates = [
    resolve(process.cwd(), 'server', 'firebase-service-account.json'),
    resolve(process.cwd(), 'dist', 'firebase-service-account.json'),
  ];
  const keyPath = candidates.find(p => existsSync(p));
  if (!keyPath) return null;
  return JSON.parse(readFileSync(keyPath, 'utf-8'));
}
```

## Deploy step (Coolify)

After merge, before redeploy: in Coolify → the app → **Environment Variables**, add:
- **Name:** `FIREBASE_SERVICE_ACCOUNT`
- **Value:** the full JSON contents of the `clinikflow-51c45` service-account key (raw JSON paste is fine)

Then redeploy. The secret lives only in Coolify's env settings — never in git, never in the APK, never returned by any endpoint.

## Verification

- `npm run check` — 79 errors (baseline, no new); none in `firebase-admin.ts`
- `npm run build` — green (399.8kb)
- Standalone logic test of `loadServiceAccount()` env parsing — **7/7** (raw JSON, base64, private-key newline preservation, empty/undefined → file fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)