### PR TITLE
fix: register FCM push token on all login paths (patient MPIN/OTP), not just staff

### DIFF
--- a/client/src/hooks/use-auth.tsx
+++ b/client/src/hooks/use-auth.tsx
@@ -36,14 +36,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     queryFn: getQueryFn({ on401: "returnNull" }),
   });
 
-  // Register the native FCM push token once an authenticated user is present.
+  // Register the native FCM push token whenever the authenticated user changes.
   // Done here (not in each login screen) so it covers every auth path — staff
-  // password, patient MPIN (which full-reloads to /home), and patient OTP — and
-  // re-registers on each app launch to keep the token fresh. No-op on web.
-  const fcmRegistered = useRef(false);
+  // password, patient MPIN (which full-reloads to /home), and patient OTP. Keyed
+  // on the user id (not a one-shot flag) so that after a logout + login-as-a-
+  // different-user on the same device, the token is re-registered and reassigned
+  // to the new user rather than staying with the previous one. No-op on web.
+  const lastRegisteredUserId = useRef<number | null>(null);
   useEffect(() => {
-    if (user && !fcmRegistered.current) {
-      fcmRegistered.current = true;
+    const currentUserId = user?.id ?? null;
+    if (currentUserId && lastRegisteredUserId.current !== currentUserId) {
+      lastRegisteredUserId.current = currentUserId;
       registerFcmToken();
     }
   }, [user]);

--- a/client/src/hooks/use-auth.tsx
+++ b/client/src/hooks/use-auth.tsx
@@ -1,4 +1,4 @@
-import { createContext, ReactNode, useContext, useState } from "react";
+import { createContext, ReactNode, useContext, useState, useEffect, useRef } from "react";
 import {
   useQuery,
   useMutation,
@@ -36,6 +36,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     queryFn: getQueryFn({ on401: "returnNull" }),
   });
 
+  // Register the native FCM push token once an authenticated user is present.
+  // Done here (not in each login screen) so it covers every auth path — staff
+  // password, patient MPIN (which full-reloads to /home), and patient OTP — and
+  // re-registers on each app launch to keep the token fresh. No-op on web.
+  const fcmRegistered = useRef(false);
+  useEffect(() => {
+    if (user && !fcmRegistered.current) {
+      fcmRegistered.current = true;
+      registerFcmToken();
+    }
+  }, [user]);
+
   const clearPasswordReset = () => {
     setMustChangePassword(false);
   };
@@ -60,7 +72,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           title: "Login successful",
           description: `Welcome back, ${(data.user || data).name}!`,
         });
-        registerFcmToken();
+        // FCM token registration is handled centrally by the auth effect above,
+        // so it also covers patient MPIN/OTP logins — no per-path call needed.
       }
     },
     onError: (error: Error) => {


### PR DESCRIPTION
## Root cause (why `device_tokens` stayed empty)

`registerFcmToken()` was invoked in **only one place** — the staff `/api/login` mutation (`use-auth.tsx`). But patients authenticate through different flows:

- **Returning patient → MPIN:** `patient-login.tsx` → `/api/auth/patient/login` (then full-reloads to `/home`)
- **Fresh patient → OTP:** `mobile-login-firebase.tsx` → `/api/auth/firebase-verify` / `/api/auth/verify-otp`

Neither patient path called `registerFcmToken()`, so **no patient ever registered a device token**. Since push notifications target patients ("Your turn has started"), `device_tokens` stayed empty and nothing was ever delivered — even with the table, server key, and APK all correctly set up.

## Fix

Move registration into an **`AuthProvider` effect keyed on the authenticated user**, instead of per-login-screen calls:

```ts
const fcmRegistered = useRef(false);
useEffect(() => {
  if (user && !fcmRegistered.current) {
    fcmRegistered.current = true;
    registerFcmToken();
  }
}, [user]);
```

This fires for **every** auth path (staff password, patient MPIN, patient OTP), survives the patient-MPIN full page reload (re-fires when `/home` loads and the `/api/user` query resolves), and re-registers on each app launch to keep the token fresh. The redundant staff-`onSuccess` call is removed. No-op on web (`registerFcmToken` guards `Capacitor.isNativePlatform()`).

## Why no new APK is needed

The Android app loads the live site in a Capacitor WebView, so this JS fix ships via a normal **web redeploy** — the already-installed APK has Firebase compiled in correctly.

## Coverage

| Login path | Sets user via | Registers token |
|---|---|---|
| Staff password (`/api/login`) | `setQueryData(["/api/user"])` | ✅ |
| Patient MPIN (`/api/auth/patient/login`, reload→`/home`) | `/api/user` query after reload | ✅ |
| Patient OTP (`/api/auth/verify-otp`) | `setQueryData(["/api/user"])` | ✅ |

## Verification

- `npm run check` — 79 errors (baseline, no new); none in `use-auth.tsx`
- `npm run build` — green (399.8kb)

## After merge

1. Redeploy the web app (Coolify).
2. Re-open the **already-installed** app, log in as the patient (MPIN or OTP).
3. `SELECT * FROM device_tokens ORDER BY created_at DESC;` → a row should finally appear.
4. Trigger a token → `in_progress` → push (foreground, then background).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved push notification registration so it automatically updates after sign-in and when switching accounts, helping ensure notifications work more reliably across logout/login flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->