### PR TITLE
feat: send push notification for every bell notification event

### DIFF
--- a/server/services/notification.ts
+++ b/server/services/notification.ts
@@ -32,7 +32,13 @@ class NotificationService {
    * so the web app is completely unaffected by this.
    */
   async createNotification(data: NotificationData) {
-    console.log('Creating notification with data:', data);
+    // Log only stable identifiers — title/message can contain doctor names,
+    // notes, and cancellation reasons (sensitive appointment context).
+    console.log('Creating notification', {
+      userId: data.userId,
+      appointmentId: data.appointmentId,
+      type: data.type,
+    });
 
     try {
       const result = await db.execute(sql`
@@ -41,7 +47,11 @@ class NotificationService {
         RETURNING *
       `);
 
-      console.log('Notification created successfully:', result.rows[0]);
+      console.log('Notification created successfully', {
+        id: (result.rows[0] as any)?.id,
+        userId: data.userId,
+        type: data.type,
+      });
 
       // Mirror the bell notification to a native push (fire-and-forget). Dynamic
       // import mirrors the pattern in storage.ts and avoids firebase-admin
@@ -157,6 +167,7 @@ class NotificationService {
     
     switch (status) {
       case "start":
+      case "in_progress": // routes.ts passes the raw 'in_progress' status — alias it to the start message so the bell (and its mirrored push) fire
         title = "Your appointment has started";
         message = `Your consultation with Dr. ${doctor.name} has begun. Please proceed to the doctor's room.`;
         break;

--- a/server/services/notification.ts
+++ b/server/services/notification.ts
@@ -9,21 +9,54 @@ interface NotificationData {
   type: string;
 }
 
+/**
+ * Map a notification type to the in-app deep-link route the push should open
+ * when tapped. Keeps the patient landing on the relevant screen rather than a
+ * generic one. Unknown types fall back to the appointments list.
+ */
+function routeForType(type: string): string {
+  if (type === 'schedule_activated') return '/booking';
+  if (type.startsWith('wallet_')) return '/wallet';
+  return '/appointments';
+}
+
 class NotificationService {
   /**
-   * Create a new notification
+   * Create a new notification.
+   *
+   * Every in-app "bell" notification funnels through this method, so it is also
+   * the single place we fire the matching native push notification. The push is
+   * dispatched fire-and-forget AFTER the DB insert succeeds, so a push failure
+   * can never break bell creation. It is a no-op for users with no registered
+   * device token (e.g. web-only users) — `sendPushToUser` early-returns then,
+   * so the web app is completely unaffected by this.
    */
   async createNotification(data: NotificationData) {
     console.log('Creating notification with data:', data);
-    
+
     try {
       const result = await db.execute(sql`
         INSERT INTO notifications (user_id, appointment_id, title, message, type)
         VALUES (${data.userId}, ${data.appointmentId}, ${data.title}, ${data.message}, ${data.type})
         RETURNING *
       `);
-      
+
       console.log('Notification created successfully:', result.rows[0]);
+
+      // Mirror the bell notification to a native push (fire-and-forget). Dynamic
+      // import mirrors the pattern in storage.ts and avoids firebase-admin
+      // init/load-order issues. Not awaited so it never blocks the response;
+      // sendPushToUser swallows its own errors internally.
+      import('../firebase-admin')
+        .then(({ sendPushToUser }) =>
+          sendPushToUser(data.userId, data.title, data.message, {
+            type: data.type,
+            appointmentId: String(data.appointmentId ?? ''),
+            route: routeForType(data.type),
+          })
+        )
+        .catch(err => console.error('Push mirror failed (bell still delivered):', err));
+
       return result.rows[0];
     } catch (error) {
       console.error('Error creating notification in database:', error);

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -2161,10 +2161,13 @@ export class DatabaseStorage implements IStorage {
       // (which createNotification — and now its mirrored push — rides on) fires only
       // on 'in_progress', not on 'completed'. So this stays a bespoke push here.
       // The former 'in_progress' -> "Your turn has started" push was removed: it is
-      // now covered centrally by the status_start bell's mirrored push in
-      // notification.ts, and keeping it here would double-notify the same patient.
-      if (updated.patientId && previousStatus !== status && status === 'completed') {
-        const { sendPushToUser } = await import('./firebase-admin');
+      // now covered centrally by the 'in_progress' status bell's mirrored push in
+      // notification.ts (generateStatusNotification), so keeping it here would
+      // double-notify the same patient.
+      // Do NOT gate on the completing appointment's patientId — walk-ins have a null
+      // patientId, but the next waiting patient (guarded below) may be a registered
+      // patient who should still be alerted.
+      if (previousStatus !== status && status === 'completed') {
         // Notify the next waiting patient (any waiting status)
         const nextPatient = await db
           .select()
@@ -2180,12 +2183,18 @@ export class DatabaseStorage implements IStorage {
           .limit(1);
 
         if (nextPatient.length > 0 && nextPatient[0].patientId) {
-          sendPushToUser(
-            nextPatient[0].patientId,
-            'Your turn is coming up',
-            `Token #${nextPatient[0].tokenNumber} — please be ready.`,
-            { route: '/appointments' }
-          );
+          // Fire-and-forget so an import/push failure can never fail the
+          // already-committed status update (mirrors createNotification).
+          import('./firebase-admin')
+            .then(({ sendPushToUser }) =>
+              sendPushToUser(
+                nextPatient[0].patientId!,
+                'Your turn is coming up',
+                `Token #${nextPatient[0].tokenNumber} — please be ready.`,
+                { route: '/appointments' }
+              )
+            )
+            .catch(err => console.error('Completed-token push failed:', err));
         }
       }
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -2156,40 +2156,36 @@ export class DatabaseStorage implements IStorage {
         throw new Error('Appointment not found');
       }
 
-      // Send push notification to patient on key status changes
-      // Guard: only notify if status actually changed (prevents duplicates on retries)
-      if (updated.patientId && previousStatus !== status && (status === 'in_progress' || status === 'completed')) {
+      // Push to the NEXT waiting patient when a token completes.
+      // This is the one push with NO backing bell notification: notifyNextPatients
+      // (which createNotification — and now its mirrored push — rides on) fires only
+      // on 'in_progress', not on 'completed'. So this stays a bespoke push here.
+      // The former 'in_progress' -> "Your turn has started" push was removed: it is
+      // now covered centrally by the status_start bell's mirrored push in
+      // notification.ts, and keeping it here would double-notify the same patient.
+      if (updated.patientId && previousStatus !== status && status === 'completed') {
         const { sendPushToUser } = await import('./firebase-admin');
-        if (status === 'in_progress') {
+        // Notify the next waiting patient (any waiting status)
+        const nextPatient = await db
+          .select()
+          .from(appointments)
+          .where(
+            and(
+              eq(appointments.scheduleId, updated.scheduleId),
+              inArray(appointments.status, ['scheduled', 'token_started']),
+              gt(appointments.tokenNumber, updated.tokenNumber)
+            )
+          )
+          .orderBy(appointments.tokenNumber)
+          .limit(1);
+
+        if (nextPatient.length > 0 && nextPatient[0].patientId) {
           sendPushToUser(
-            updated.patientId,
-            'Your turn has started',
-            `Token #${updated.tokenNumber} — please proceed to the consultation room.`,
+            nextPatient[0].patientId,
+            'Your turn is coming up',
+            `Token #${nextPatient[0].tokenNumber} — please be ready.`,
             { route: '/appointments' }
           );
-        } else if (status === 'completed') {
-          // Notify the next waiting patient (any waiting status)
-          const nextPatient = await db
-            .select()
-            .from(appointments)
-            .where(
-              and(
-                eq(appointments.scheduleId, updated.scheduleId),
-                inArray(appointments.status, ['scheduled', 'token_started']),
-                gt(appointments.tokenNumber, updated.tokenNumber)
-              )
-            )
-            .orderBy(appointments.tokenNumber)
-            .limit(1);
-
-          if (nextPatient.length > 0 && nextPatient[0].patientId) {
-            sendPushToUser(
-              nextPatient[0].patientId,
-              'Your turn is coming up',
-              `Token #${nextPatient[0].tokenNumber} — please be ready.`,
-              { route: '/appointments' }
-            );
-          }
         }
       }
 


### PR DESCRIPTION
## Summary

Previously, patients received a **native (FCM) push** for only **2** events — token → `in_progress` ("Your turn has started") and token → `completed` ("Your turn is coming up" to the next patient). Every other in-app **bell** notification (doctor arrival, cancellations, favorited-schedule activation, refunds, pause/resume, etc.) was **bell-only** and invisible to a patient whose app was backgrounded/closed.

Per client request, this PR makes **every bell notification also send a push**.

## How it works

Every in-app bell notification funnels through a single chokepoint — `NotificationService.createNotification()`. We mirror the bell to a native push from there, so **one edit covers all ~15 events**: status changes, next-in-line/upcoming, doctor arrival, schedule pause/resume/complete/cancel, favorited-schedule activation, and wallet/refunds.

## Changes

**`server/services/notification.ts`**
- After the bell DB insert succeeds, dispatch `sendPushToUser(userId, title, message, { type, appointmentId, route })` **fire-and-forget** (dynamic import, mirrors the existing `storage.ts` pattern). Not awaited, so a push failure can never break bell creation.
- Added a `routeForType()` deep-link map for the push payload (`schedule_activated` → booking, `wallet_*` → wallet, else → appointments).

**`server/storage.ts`**
- **Removed** the now-duplicate `in_progress` → "Your turn has started" push (it is now covered centrally by the `status_start` bell's mirrored push; keeping it would double-notify the same patient).
- **Kept** the `completed` → next-patient "Your turn is coming up" push, which has **no backing bell** (`notifyNextPatients` fires only on `in_progress`, not on `completed`), so it must stay a bespoke push.

## Web app is unaffected

Two independent guarantees ensure this never fires on web:
1. `registerFcmToken()` is a no-op on web (`!Capacitor.isNativePlatform()`), so web sessions never create a `device_tokens` row.
2. `sendPushToUser` early-returns when the user has no tokens — does nothing, no error.

The bell DB-insert path is unchanged, so the web bell behaves exactly as before.

## Notes / scope

- **Deep-link on tap is not wired client-side yet.** The `route` is plumbed into the push payload, but `notification-popover.tsx` still hardcodes `navigate('/appointments')` on tap, so every tapped push opens Appointments (same as before — no regression). Wiring true deep-linking is a small optional follow-up.
- The `addMemoryNotification()` fallback (only used if the `notifications` table is missing — not the case in prod) bypasses the chokepoint and is intentionally **not** covered. Documented in code.

## Verification

- `npm run check` → holds at the **79-error baseline** (no new type errors).
- `npm run build` → passes (client + server bundle clean).

## Manual test (post-deploy)

Trigger events that were previously bell-only against a test patient with a registered device and confirm a tray push now appears:
- Mark doctor **arrived** → "Your doctor has arrived"
- **Cancel** a schedule → "Your appointment has been cancelled"
- Activate a **favorited** schedule → "Booking started for favorited schedule!"
- Process a **refund** → "Refund Processed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-app notifications can now also be mirrored to native push notifications, including deep links that route to the most relevant screen.
* **Bug Fixes**
  * Appointment status updates no longer send an extra “Your turn has started” push at the wrong time.
  * When an appointment is completed, only the correct completion-related notifications are sent, and the next waiting patient still receives “Your turn is coming up.”
  * Notifications now treat **in_progress** messages consistently with the **start** flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->